### PR TITLE
refactor(core): embedding型をnumber[] | nullに修正

### DIFF
--- a/packages/core/src/entities/memory.ts
+++ b/packages/core/src/entities/memory.ts
@@ -3,8 +3,8 @@ export interface Memory {
   id: string
   /** Q&Aペアのテキスト。空文字不可 */
   content: string
-  /** ベクトル表現 */
-  embedding: number[]
+  /** ベクトル表現。list取得時はnull（大きなペイロードのため） */
+  embedding: number[] | null
   metadata: MemoryMetadata
   createdAt: Date
   updatedAt: Date

--- a/packages/storage-postgres/src/postgres-storage-repository.ts
+++ b/packages/storage-postgres/src/postgres-storage-repository.ts
@@ -17,7 +17,7 @@ function toMemory(row: DbRow): Memory {
   return {
     id: row.id,
     content: row.content,
-    embedding: [], // embeddings not fetched by default (large payload)
+    embedding: null, // embeddings not fetched by default (large payload)
     metadata: {
       sessionId: row.sessionId ?? '',
       projectPath: row.projectPath ?? undefined,
@@ -59,6 +59,7 @@ export class PostgresStorageRepository implements StorageRepository {
   }
 
   async save(memory: Memory): Promise<void> {
+    if (!memory.embedding) throw new Error('Cannot save memory without embedding')
     const embeddingLiteral = `[${memory.embedding.join(',')}]`
 
     await this.db

--- a/packages/storage-postgres/tests/postgres-storage-repository.test.ts
+++ b/packages/storage-postgres/tests/postgres-storage-repository.test.ts
@@ -71,6 +71,13 @@ describe('PostgresStorageRepository', () => {
       const result = await repo.findById(randomUUID())
       expect(result).toBeNull()
     })
+
+    it('returns null embedding for found memory', async () => {
+      const memory = makeMemory()
+      await repo.save(memory)
+      const found = await repo.findById(memory.id)
+      expect(found!.embedding).toBeNull()
+    })
   })
 
   describe('saveBatch', () => {
@@ -152,6 +159,12 @@ describe('PostgresStorageRepository', () => {
       const session1 = await repo.list({ limit: 10, offset: 0, sessionId: 's1' })
       expect(session1).toHaveLength(2)
       expect(session1.every((m) => m.metadata.sessionId === 's1')).toBe(true)
+    })
+
+    it('returns null embedding for listed memories', async () => {
+      await repo.save(makeMemory())
+      const results = await repo.list({ limit: 10, offset: 0 })
+      expect(results[0]!.embedding).toBeNull()
     })
 
     it('sorts by createdAt desc', async () => {


### PR DESCRIPTION
## Summary

- `Memory.embedding` の型を `number[]` → `number[] | null` に変更
- `list` / `findById` は embedding を取得しないため `null` を返す（以前は空配列 `[]`）
- `save()` に null ガードを追加（embedding なしの保存を防止）

## Test plan

- [ ] `list` が null embedding を返すテスト追加
- [ ] `findById` が null embedding を返すテスト追加
- [ ] 既存テストが全てパス
- [ ] `pnpm build` で型エラーなし

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)