### PR TITLE
perf(embedding-onnx): embedBatchの並列処理化

### DIFF
--- a/packages/embedding-onnx/src/onnx-embedding-provider.ts
+++ b/packages/embedding-onnx/src/onnx-embedding-provider.ts
@@ -33,11 +33,12 @@ export class OnnxEmbeddingProvider implements EmbeddingProvider {
 
   async embedBatch(texts: string[]): Promise<number[][]> {
     const extractor = await this.getExtractor()
-    const results: number[][] = []
-    for (const text of texts) {
-      const output = await extractor(text, { pooling: 'mean', normalize: true })
-      results.push(Array.from(output.data as Float32Array))
-    }
+    const results = await Promise.all(
+      texts.map(async (text) => {
+        const output = await extractor(text, { pooling: 'mean', normalize: true })
+        return Array.from(output.data as Float32Array)
+      }),
+    )
     return results
   }
 

--- a/packages/embedding-onnx/tests/onnx-embedding-provider.test.ts
+++ b/packages/embedding-onnx/tests/onnx-embedding-provider.test.ts
@@ -43,6 +43,18 @@ describe('OnnxEmbeddingProvider', () => {
       expect(vectors).toHaveLength(3)
       expect(vectors.every((v) => v.length === 384)).toBe(true)
     })
+
+    it('embedBatch should produce same results as individual embed calls', async () => {
+      const texts = ['hello', 'world']
+      const [single1, single2] = await Promise.all([
+        provider.embed('hello'),
+        provider.embed('world'),
+      ])
+      const batch = await provider.embedBatch(texts)
+      expect(batch).toHaveLength(2)
+      expect(batch[0]).toEqual(single1)
+      expect(batch[1]).toEqual(single2)
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

- `embedBatch` の逐次 for ループを `Promise.all` による並列処理に変更
- 大量チャンク保存時のパフォーマンス改善

## Test plan

- [ ] `embedBatch` が個別 `embed` と同じ結果を返す
- [ ] 既存テストが全てパス

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)