### PR TITLE
feat(core): モニタリング・メトリクスの追加

### DIFF
--- a/packages/core/src/entities/memory.ts
+++ b/packages/core/src/entities/memory.ts
@@ -35,4 +35,8 @@ export interface StorageStats {
   oldestMemory: Date | null
   newestMemory: Date | null
   averageContentLength: number
+  /** Total count of manual memories */
+  manualCount: number
+  /** Total count of auto memories */
+  autoCount: number
 }

--- a/packages/core/tests/use-cases/get-stats.test.ts
+++ b/packages/core/tests/use-cases/get-stats.test.ts
@@ -9,6 +9,8 @@ describe('GetStatsUseCase', () => {
       oldestMemory: null,
       newestMemory: null,
       averageContentLength: 150,
+      manualCount: 30,
+      autoCount: 12,
     }
     const storage = { getStats: vi.fn().mockResolvedValue(stats) } as any
     const useCase = new GetStatsUseCase(storage)

--- a/packages/mcp-server/src/tools/memory-save.ts
+++ b/packages/mcp-server/src/tools/memory-save.ts
@@ -13,8 +13,12 @@ export function registerMemorySaveTool(server: McpServer, container: Container):
       tags: z.array(z.string()).optional(),
     },
     async (args) => {
+      const start = performance.now()
       const result = await container.saveMemory.saveManual(args)
-      const text = result.saved ? 'Memory saved successfully.' : 'Duplicate memory skipped.'
+      const durationMs = Math.round(performance.now() - start)
+      const text = result.saved
+        ? `Memory saved successfully. (${durationMs}ms)`
+        : `Duplicate memory skipped. (${durationMs}ms)`
       return {
         content: [{ type: 'text', text }],
       }

--- a/packages/mcp-server/src/tools/memory-search.ts
+++ b/packages/mcp-server/src/tools/memory-search.ts
@@ -19,6 +19,7 @@ export function registerMemorySearchTool(server: McpServer, container: Container
         .describe('Search across all projects instead of scoping to projectPath'),
     },
     async (args) => {
+      const start = performance.now()
       const filter: SearchFilter = {}
       if (!args.allProjects && args.projectPath) {
         filter.projectPath = args.projectPath
@@ -32,10 +33,11 @@ export function registerMemorySearchTool(server: McpServer, container: Container
         args.limit,
         hasFilter ? filter : undefined,
       )
+      const durationMs = Math.round(performance.now() - start)
 
       if (results.length === 0) {
         return {
-          content: [{ type: 'text', text: 'No memories found.' }],
+          content: [{ type: 'text', text: `No memories found. (${durationMs}ms)` }],
         }
       }
 
@@ -50,7 +52,7 @@ export function registerMemorySearchTool(server: McpServer, container: Container
         .join('\n\n')
 
       return {
-        content: [{ type: 'text', text: formatted }],
+        content: [{ type: 'text', text: `${formatted}\n\n(${durationMs}ms)` }],
       }
     },
   )

--- a/packages/mcp-server/src/tools/memory-stats.ts
+++ b/packages/mcp-server/src/tools/memory-stats.ts
@@ -3,14 +3,19 @@ import type { Container } from '../container.js'
 
 export function registerMemoryStatsTool(server: McpServer, container: Container): void {
   server.tool('memory_stats', 'Get memory storage statistics', async () => {
+    const start = performance.now()
     const stats = await container.getStats.execute()
+    const durationMs = Math.round(performance.now() - start)
 
     const lines = [
       `Total memories: ${stats.totalMemories}`,
+      `  Manual: ${stats.manualCount}`,
+      `  Auto: ${stats.autoCount}`,
       `Total sessions: ${stats.totalSessions}`,
       `Oldest memory: ${stats.oldestMemory ? stats.oldestMemory.toISOString() : 'N/A'}`,
       `Newest memory: ${stats.newestMemory ? stats.newestMemory.toISOString() : 'N/A'}`,
       `Average content length: ${stats.averageContentLength.toFixed(1)} chars`,
+      `Query time: ${durationMs}ms`,
     ]
 
     return {

--- a/packages/storage-postgres/src/postgres-storage-repository.ts
+++ b/packages/storage-postgres/src/postgres-storage-repository.ts
@@ -249,6 +249,8 @@ export class PostgresStorageRepository implements StorageRepository {
         averageContentLength: sql<number>`COALESCE(AVG(LENGTH(${memories.content})), 0)::float`,
         oldestMemory: sql<Date | null>`MIN(${memories.createdAt})`,
         newestMemory: sql<Date | null>`MAX(${memories.createdAt})`,
+        manualCount: sql<number>`COUNT(*) FILTER (WHERE ${memories.source} = 'manual')::int`,
+        autoCount: sql<number>`COUNT(*) FILTER (WHERE ${memories.source} = 'auto')::int`,
       })
       .from(memories)
 
@@ -260,6 +262,8 @@ export class PostgresStorageRepository implements StorageRepository {
         averageContentLength: 0,
         oldestMemory: null,
         newestMemory: null,
+        manualCount: 0,
+        autoCount: 0,
       }
     }
     return {
@@ -268,6 +272,8 @@ export class PostgresStorageRepository implements StorageRepository {
       averageContentLength: row.averageContentLength,
       oldestMemory: row.oldestMemory ? new Date(row.oldestMemory) : null,
       newestMemory: row.newestMemory ? new Date(row.newestMemory) : null,
+      manualCount: row.manualCount,
+      autoCount: row.autoCount,
     }
   }
 }

--- a/packages/storage-postgres/tests/postgres-storage-repository.test.ts
+++ b/packages/storage-postgres/tests/postgres-storage-repository.test.ts
@@ -342,6 +342,8 @@ describe('PostgresStorageRepository', () => {
       expect(stats.averageContentLength).toBe(0)
       expect(stats.oldestMemory).toBeNull()
       expect(stats.newestMemory).toBeNull()
+      expect(stats.manualCount).toBe(0)
+      expect(stats.autoCount).toBe(0)
     })
 
     it('returns correct stats with data', async () => {
@@ -360,6 +362,8 @@ describe('PostgresStorageRepository', () => {
       expect(stats.averageContentLength).toBeGreaterThan(0)
       expect(stats.oldestMemory).toBeInstanceOf(Date)
       expect(stats.newestMemory).toBeInstanceOf(Date)
+      expect(stats.manualCount).toBe(2)
+      expect(stats.autoCount).toBe(1)
     })
   })
 })


### PR DESCRIPTION
## Summary

- `StorageStats` に `manualCount` / `autoCount` を追加
- `memory_save`, `memory_search`, `memory_stats` にレイテンシ計測（performance.now）追加
- PostgreSQL `COUNT(*) FILTER` でsource別カウント

## Test plan

- [ ] getStatsでmanualCount/autoCountが返る
- [ ] 空DBでもゼロが返る
- [ ] 既存テスト全パス

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)