### PR TITLE
feat: リンタールール強化（jsdocプラグイン・no-magic-numbers）

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,15 @@
 {
+  "plugins": ["jsdoc"],
   "rules": {
-    "all": "warn"
+    "all": "warn",
+    "no-magic-numbers": [
+      "warn",
+      {
+        "ignore": [0, 1, -1, 2],
+        "ignoreEnums": true,
+        "ignoreReadonlyClassProperties": true
+      }
+    ]
   },
-  "ignorePatterns": ["dist/", "node_modules/", "coverage/"]
+  "ignorePatterns": ["dist/", "node_modules/", "coverage/", "**/*.test.ts"]
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,7 +7,7 @@ pre-commit:
       stage_fixed: true
     oxlint:
       glob: "*.{ts,tsx,js}"
-      run: pnpm oxlint {staged_files}
+      run: pnpm oxlint -c .oxlintrc.json {staged_files}
     knip:
       run: pnpm knip
     dep-check:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "pnpm -r run build",
     "test": "pnpm -r run test",
     "test:unit": "pnpm --filter @claude-memory/core run test",
-    "lint": "oxlint . && biome check packages/*/src",
+    "lint": "oxlint -c .oxlintrc.json packages/*/src && biome check packages/*/src",
     "format": "biome check --write .",
     "knip": "knip",
     "dep-check": "depcruise --validate packages/"

--- a/packages/core/src/use-cases/export-memory.ts
+++ b/packages/core/src/use-cases/export-memory.ts
@@ -1,4 +1,3 @@
-import type { Memory } from '../entities/memory.js'
 import type { StorageRepository } from '../interfaces/storage-repository.js'
 
 export interface ExportedMemory {

--- a/packages/core/src/use-cases/search-memory.ts
+++ b/packages/core/src/use-cases/search-memory.ts
@@ -65,8 +65,10 @@ export class SearchMemoryUseCase {
   }
 
   private timeDecay(createdAt: Date, now: Date): number {
-    const daysDiff = (now.getTime() - createdAt.getTime()) / (1000 * 60 * 60 * 24)
+    const MS_PER_DAY = 86_400_000
+    const HALF_LIFE_BASE = 0.5
+    const daysDiff = (now.getTime() - createdAt.getTime()) / MS_PER_DAY
     const halfLife = SEARCH_DEFAULTS.decayHalfLifeDays
-    return Math.pow(0.5, daysDiff / halfLife)
+    return Math.pow(HALF_LIFE_BASE, daysDiff / halfLife)
   }
 }

--- a/packages/mcp-server/src/tools/memory-list.ts
+++ b/packages/mcp-server/src/tools/memory-list.ts
@@ -1,3 +1,4 @@
+import { SEARCH_DEFAULTS } from '@claude-memory/core'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { Container } from '../container.js'
@@ -7,7 +8,7 @@ export function registerMemoryListTool(server: McpServer, container: Container):
     'memory_list',
     'List memories with pagination',
     {
-      limit: z.number().optional().default(20),
+      limit: z.number().optional().default(SEARCH_DEFAULTS.maxResults),
       offset: z.number().optional().default(0),
       source: z.enum(['manual', 'auto']).optional(),
       tags: z.array(z.string()).optional(),

--- a/packages/mcp-server/src/tools/memory-search.ts
+++ b/packages/mcp-server/src/tools/memory-search.ts
@@ -1,7 +1,9 @@
-import type { SearchFilter } from '@claude-memory/core'
+import { SEARCH_DEFAULTS, type SearchFilter } from '@claude-memory/core'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { Container } from '../container.js'
+
+const SCORE_DECIMAL_PLACES = 4
 
 export function registerMemorySearchTool(server: McpServer, container: Container): void {
   server.tool(
@@ -9,7 +11,7 @@ export function registerMemorySearchTool(server: McpServer, container: Container
     'Search memories with hybrid search (keyword + vector)',
     {
       query: z.string().min(1),
-      limit: z.number().optional().default(20),
+      limit: z.number().optional().default(SEARCH_DEFAULTS.maxResults),
       projectPath: z.string().optional(),
       tags: z.array(z.string()).optional(),
       allProjects: z
@@ -44,7 +46,7 @@ export function registerMemorySearchTool(server: McpServer, container: Container
       const formatted = results
         .map((r, i) => {
           const lines = [
-            `[${i + 1}] matchType=${r.matchType} score=${r.score.toFixed(4)}`,
+            `[${i + 1}] matchType=${r.matchType} score=${r.score.toFixed(SCORE_DECIMAL_PLACES)}`,
             r.memory.content,
           ]
           return lines.join('\n')


### PR DESCRIPTION
## Summary

- OXLint jsdoc プラグイン有効化（JSDocの内容検証）
- `no-magic-numbers` ルール追加（warn）
- マジックナンバーを名前付き定数に置換
  - `1000 * 60 * 60 * 24` → `MS_PER_DAY = 86_400_000`
  - `0.5` → `HALF_LIFE_BASE`
  - `default(20)` → `SEARCH_DEFAULTS.maxResults`
  - `.toFixed(4)` → `SCORE_DECIMAL_PLACES`
- 未使用import修正（export-memory.ts）
- lefthook / lint スクリプトに `.oxlintrc.json` 参照を追加
- テストファイルは `ignorePatterns` で除外

### 未対応（OXLint未サポート）
- `require-jsdoc`（JSDocの存在チェック）— OXLint v1.56.0 では未対応。将来的にESLint追加時に検討
- `sql.raw` 使用制限 — ESLint `no-restricted-syntax` が必要

## Test plan

- [ ] `npx oxlint -c .oxlintrc.json packages/*/src/` で 0 warnings
- [ ] `pnpm build` 成功
- [ ] 全テストパス

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)