### PR TITLE
fix: dependency-cruiserの設定修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "oxlint -c .oxlintrc.json packages/*/src && biome check packages/*/src",
     "format": "biome check --write .",
     "knip": "knip",
-    "dep-check": "depcruise --validate packages/",
+    "dep-check": "depcruise --config .dependency-cruiser.cjs packages/",
     "prepare": "husky"
   },
   "pnpm": {


### PR DESCRIPTION
## Summary

- `--validate` フラグが dependency-cruiser v17 で無効 → `--config .dependency-cruiser.cjs` に変更
- `pnpm dep-check` で実際に58モジュール・63依存関係を検証するようになった

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)