### PR TITLE
refactor(storage-postgres): sql.rawをパラメータバインディングに置換

### DIFF
--- a/packages/storage-postgres/src/postgres-storage-repository.ts
+++ b/packages/storage-postgres/src/postgres-storage-repository.ts
@@ -224,7 +224,7 @@ export class PostgresStorageRepository implements StorageRepository {
       conditions.push(tagsOverlapCondition(filter.tags))
     }
 
-    const distanceExpr = sql<number>`${memories.embedding} <=> ${sql.raw(`'${embeddingLiteral}'`)}::vector`
+    const distanceExpr = sql<number>`${memories.embedding} <=> ${embeddingLiteral}::vector`
 
     const rows = await this.db
       .select({


### PR DESCRIPTION
## Summary

- searchByVectorの `sql.raw()` をDrizzleパラメータバインディングに置換
- SQLインジェクションリスクの排除
- pgvectorの `<=>` 演算子がパラメータバインディングで正常動作することを確認

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)