### PR TITLE
feat(mcp-server): MCPツール層のエラーレスポンス統一

### DIFF
--- a/packages/mcp-server/src/tools/error-handler.ts
+++ b/packages/mcp-server/src/tools/error-handler.ts
@@ -1,0 +1,31 @@
+import { MemoryError } from '@claude-memory/core'
+
+/** Structured MCP tool result compatible with MCP SDK CallToolResult */
+interface McpToolResult {
+  [key: string]: unknown
+  content: { type: 'text'; text: string }[]
+  isError?: boolean
+}
+
+/**
+ * Wraps a tool handler to catch domain errors and return structured MCP error responses.
+ * - Known domain errors (MemoryError subclasses) return user-friendly messages.
+ * - Unknown errors return a generic internal error message.
+ */
+export async function handleToolError(fn: () => Promise<McpToolResult>): Promise<McpToolResult> {
+  try {
+    return await fn()
+  } catch (error) {
+    if (error instanceof MemoryError) {
+      return {
+        content: [{ type: 'text', text: `Error: ${error.message}` }],
+        isError: true,
+      }
+    }
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return {
+      content: [{ type: 'text', text: `Internal error: ${message}` }],
+      isError: true,
+    }
+  }
+}

--- a/packages/mcp-server/src/tools/memory-cleanup.ts
+++ b/packages/mcp-server/src/tools/memory-cleanup.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { Container } from '../container.js'
+import { handleToolError } from './error-handler.js'
 
 export function registerMemoryCleanupTool(server: McpServer, container: Container): void {
   server.tool(
@@ -15,16 +16,18 @@ export function registerMemoryCleanupTool(server: McpServer, container: Containe
         .describe('Preview what would be deleted without actually deleting'),
     },
     async (args) => {
-      const result = await container.cleanupMemory.execute(args)
-      const action = result.dryRun ? 'Would delete' : 'Deleted'
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `${action} ${result.deletedCount} memories (not accessed in ${args.olderThanDays} days).`,
-          },
-        ],
-      }
+      return handleToolError(async () => {
+        const result = await container.cleanupMemory.execute(args)
+        const action = result.dryRun ? 'Would delete' : 'Deleted'
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `${action} ${result.deletedCount} memories (not accessed in ${args.olderThanDays} days).`,
+            },
+          ],
+        }
+      })
     },
   )
 }

--- a/packages/mcp-server/src/tools/memory-clear.ts
+++ b/packages/mcp-server/src/tools/memory-clear.ts
@@ -1,11 +1,14 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { Container } from '../container.js'
+import { handleToolError } from './error-handler.js'
 
 export function registerMemoryClearTool(server: McpServer, container: Container): void {
   server.tool('memory_clear', 'Clear all memories', async () => {
-    await container.clearMemory.execute()
-    return {
-      content: [{ type: 'text', text: 'All memories cleared.' }],
-    }
+    return handleToolError(async () => {
+      await container.clearMemory.execute()
+      return {
+        content: [{ type: 'text', text: 'All memories cleared.' }],
+      }
+    })
   })
 }

--- a/packages/mcp-server/src/tools/memory-delete.ts
+++ b/packages/mcp-server/src/tools/memory-delete.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { Container } from '../container.js'
+import { handleToolError } from './error-handler.js'
 
 export function registerMemoryDeleteTool(server: McpServer, container: Container): void {
   server.tool(
@@ -10,10 +11,12 @@ export function registerMemoryDeleteTool(server: McpServer, container: Container
       id: z.string().uuid(),
     },
     async (args) => {
-      await container.deleteMemory.execute(args.id)
-      return {
-        content: [{ type: 'text', text: `Memory ${args.id} deleted.` }],
-      }
+      return handleToolError(async () => {
+        await container.deleteMemory.execute(args.id)
+        return {
+          content: [{ type: 'text', text: `Memory ${args.id} deleted.` }],
+        }
+      })
     },
   )
 }

--- a/packages/mcp-server/src/tools/memory-export.ts
+++ b/packages/mcp-server/src/tools/memory-export.ts
@@ -1,11 +1,14 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { Container } from '../container.js'
+import { handleToolError } from './error-handler.js'
 
 export function registerMemoryExportTool(server: McpServer, container: Container): void {
   server.tool('memory_export', 'Export all memories as JSON for backup', async () => {
-    const data = await container.exportMemory.execute()
-    return {
-      content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
-    }
+    return handleToolError(async () => {
+      const data = await container.exportMemory.execute()
+      return {
+        content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+      }
+    })
   })
 }

--- a/packages/mcp-server/src/tools/memory-import.ts
+++ b/packages/mcp-server/src/tools/memory-import.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { Container } from '../container.js'
+import { handleToolError } from './error-handler.js'
 
 const exportedMemorySchema = z.array(
   z.object({
@@ -23,11 +24,13 @@ export function registerMemoryImportTool(server: McpServer, container: Container
       data: z.string().min(1).describe('JSON string of exported memories array'),
     },
     async (args) => {
-      const parsed = exportedMemorySchema.parse(JSON.parse(args.data))
-      const result = await container.importMemory.execute(parsed)
-      return {
-        content: [{ type: 'text', text: `Imported ${result.imported} memories.` }],
-      }
+      return handleToolError(async () => {
+        const parsed = exportedMemorySchema.parse(JSON.parse(args.data))
+        const result = await container.importMemory.execute(parsed)
+        return {
+          content: [{ type: 'text', text: `Imported ${result.imported} memories.` }],
+        }
+      })
     },
   )
 }

--- a/packages/mcp-server/src/tools/memory-list.ts
+++ b/packages/mcp-server/src/tools/memory-list.ts
@@ -2,6 +2,7 @@ import { SEARCH_DEFAULTS } from '@claude-memory/core'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { Container } from '../container.js'
+import { handleToolError } from './error-handler.js'
 
 export function registerMemoryListTool(server: McpServer, container: Container): void {
   server.tool(
@@ -14,32 +15,34 @@ export function registerMemoryListTool(server: McpServer, container: Container):
       tags: z.array(z.string()).optional(),
     },
     async (args) => {
-      const memories = await container.listMemories.execute({
-        limit: args.limit,
-        offset: args.offset,
-        source: args.source,
-        tags: args.tags,
-      })
-
-      if (memories.length === 0) {
-        return {
-          content: [{ type: 'text', text: 'No memories found.' }],
-        }
-      }
-
-      const formatted = memories
-        .map((m, i) => {
-          const lines = [
-            `[${i + 1}] id=${m.id} source=${m.metadata.source} createdAt=${m.createdAt.toISOString()}`,
-            m.content,
-          ]
-          return lines.join('\n')
+      return handleToolError(async () => {
+        const memories = await container.listMemories.execute({
+          limit: args.limit,
+          offset: args.offset,
+          source: args.source,
+          tags: args.tags,
         })
-        .join('\n\n')
 
-      return {
-        content: [{ type: 'text', text: formatted }],
-      }
+        if (memories.length === 0) {
+          return {
+            content: [{ type: 'text', text: 'No memories found.' }],
+          }
+        }
+
+        const formatted = memories
+          .map((m, i) => {
+            const lines = [
+              `[${i + 1}] id=${m.id} source=${m.metadata.source} createdAt=${m.createdAt.toISOString()}`,
+              m.content,
+            ]
+            return lines.join('\n')
+          })
+          .join('\n\n')
+
+        return {
+          content: [{ type: 'text', text: formatted }],
+        }
+      })
     },
   )
 }

--- a/packages/mcp-server/src/tools/memory-save.ts
+++ b/packages/mcp-server/src/tools/memory-save.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { Container } from '../container.js'
+import { handleToolError } from './error-handler.js'
 
 export function registerMemorySaveTool(server: McpServer, container: Container): void {
   server.tool(
@@ -13,15 +14,17 @@ export function registerMemorySaveTool(server: McpServer, container: Container):
       tags: z.array(z.string()).optional(),
     },
     async (args) => {
-      const start = performance.now()
-      const result = await container.saveMemory.saveManual(args)
-      const durationMs = Math.round(performance.now() - start)
-      const text = result.saved
-        ? `Memory saved successfully. (${durationMs}ms)`
-        : `Duplicate memory skipped. (${durationMs}ms)`
-      return {
-        content: [{ type: 'text', text }],
-      }
+      return handleToolError(async () => {
+        const start = performance.now()
+        const result = await container.saveMemory.saveManual(args)
+        const durationMs = Math.round(performance.now() - start)
+        const text = result.saved
+          ? `Memory saved successfully. (${durationMs}ms)`
+          : `Duplicate memory skipped. (${durationMs}ms)`
+        return {
+          content: [{ type: 'text', text }],
+        }
+      })
     },
   )
 }

--- a/packages/mcp-server/src/tools/memory-search.ts
+++ b/packages/mcp-server/src/tools/memory-search.ts
@@ -2,6 +2,7 @@ import { SEARCH_DEFAULTS, type SearchFilter } from '@claude-memory/core'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { Container } from '../container.js'
+import { handleToolError } from './error-handler.js'
 
 const SCORE_DECIMAL_PLACES = 4
 
@@ -21,41 +22,43 @@ export function registerMemorySearchTool(server: McpServer, container: Container
         .describe('Search across all projects instead of scoping to projectPath'),
     },
     async (args) => {
-      const start = performance.now()
-      const filter: SearchFilter = {}
-      if (!args.allProjects && args.projectPath) {
-        filter.projectPath = args.projectPath
-      }
-      if (args.tags) {
-        filter.tags = args.tags
-      }
-      const hasFilter = Object.keys(filter).length > 0
-      const results = await container.searchMemory.search(
-        args.query,
-        args.limit,
-        hasFilter ? filter : undefined,
-      )
-      const durationMs = Math.round(performance.now() - start)
-
-      if (results.length === 0) {
-        return {
-          content: [{ type: 'text', text: `No memories found. (${durationMs}ms)` }],
+      return handleToolError(async () => {
+        const start = performance.now()
+        const filter: SearchFilter = {}
+        if (!args.allProjects && args.projectPath) {
+          filter.projectPath = args.projectPath
         }
-      }
+        if (args.tags) {
+          filter.tags = args.tags
+        }
+        const hasFilter = Object.keys(filter).length > 0
+        const results = await container.searchMemory.search(
+          args.query,
+          args.limit,
+          hasFilter ? filter : undefined,
+        )
+        const durationMs = Math.round(performance.now() - start)
 
-      const formatted = results
-        .map((r, i) => {
-          const lines = [
-            `[${i + 1}] matchType=${r.matchType} score=${r.score.toFixed(SCORE_DECIMAL_PLACES)}`,
-            r.memory.content,
-          ]
-          return lines.join('\n')
-        })
-        .join('\n\n')
+        if (results.length === 0) {
+          return {
+            content: [{ type: 'text', text: `No memories found. (${durationMs}ms)` }],
+          }
+        }
 
-      return {
-        content: [{ type: 'text', text: `${formatted}\n\n(${durationMs}ms)` }],
-      }
+        const formatted = results
+          .map((r, i) => {
+            const lines = [
+              `[${i + 1}] matchType=${r.matchType} score=${r.score.toFixed(SCORE_DECIMAL_PLACES)}`,
+              r.memory.content,
+            ]
+            return lines.join('\n')
+          })
+          .join('\n\n')
+
+        return {
+          content: [{ type: 'text', text: `${formatted}\n\n(${durationMs}ms)` }],
+        }
+      })
     },
   )
 }

--- a/packages/mcp-server/src/tools/memory-stats.ts
+++ b/packages/mcp-server/src/tools/memory-stats.ts
@@ -1,25 +1,28 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { Container } from '../container.js'
+import { handleToolError } from './error-handler.js'
 
 export function registerMemoryStatsTool(server: McpServer, container: Container): void {
   server.tool('memory_stats', 'Get memory storage statistics', async () => {
-    const start = performance.now()
-    const stats = await container.getStats.execute()
-    const durationMs = Math.round(performance.now() - start)
+    return handleToolError(async () => {
+      const start = performance.now()
+      const stats = await container.getStats.execute()
+      const durationMs = Math.round(performance.now() - start)
 
-    const lines = [
-      `Total memories: ${stats.totalMemories}`,
-      `  Manual: ${stats.manualCount}`,
-      `  Auto: ${stats.autoCount}`,
-      `Total sessions: ${stats.totalSessions}`,
-      `Oldest memory: ${stats.oldestMemory ? stats.oldestMemory.toISOString() : 'N/A'}`,
-      `Newest memory: ${stats.newestMemory ? stats.newestMemory.toISOString() : 'N/A'}`,
-      `Average content length: ${stats.averageContentLength.toFixed(1)} chars`,
-      `Query time: ${durationMs}ms`,
-    ]
+      const lines = [
+        `Total memories: ${stats.totalMemories}`,
+        `  Manual: ${stats.manualCount}`,
+        `  Auto: ${stats.autoCount}`,
+        `Total sessions: ${stats.totalSessions}`,
+        `Oldest memory: ${stats.oldestMemory ? stats.oldestMemory.toISOString() : 'N/A'}`,
+        `Newest memory: ${stats.newestMemory ? stats.newestMemory.toISOString() : 'N/A'}`,
+        `Average content length: ${stats.averageContentLength.toFixed(1)} chars`,
+        `Query time: ${durationMs}ms`,
+      ]
 
-    return {
-      content: [{ type: 'text', text: lines.join('\n') }],
-    }
+      return {
+        content: [{ type: 'text', text: lines.join('\n') }],
+      }
+    })
   })
 }

--- a/packages/mcp-server/src/tools/memory-update.ts
+++ b/packages/mcp-server/src/tools/memory-update.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { Container } from '../container.js'
+import { handleToolError } from './error-handler.js'
 
 export function registerMemoryUpdateTool(server: McpServer, container: Container): void {
   server.tool(
@@ -12,10 +13,12 @@ export function registerMemoryUpdateTool(server: McpServer, container: Container
       tags: z.array(z.string()).optional(),
     },
     async (args) => {
-      await container.updateMemory.execute(args)
-      return {
-        content: [{ type: 'text', text: `Memory ${args.id} updated.` }],
-      }
+      return handleToolError(async () => {
+        await container.updateMemory.execute(args)
+        return {
+          content: [{ type: 'text', text: `Memory ${args.id} updated.` }],
+        }
+      })
     },
   )
 }

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -1,12 +1,21 @@
+import {
+  EmbeddingFailedError,
+  MemoryNotFoundError,
+  StorageConnectionError,
+} from '@claude-memory/core'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { describe, expect, it, vi } from 'vitest'
 import type { Container } from '../src/container.js'
 import { registerMemoryCleanupTool } from '../src/tools/memory-cleanup.js'
+import { registerMemoryClearTool } from '../src/tools/memory-clear.js'
 import { registerMemoryDeleteTool } from '../src/tools/memory-delete.js'
 import { registerMemoryExportTool } from '../src/tools/memory-export.js'
+import { registerMemoryImportTool } from '../src/tools/memory-import.js'
+import { registerMemoryListTool } from '../src/tools/memory-list.js'
 import { registerMemorySaveTool } from '../src/tools/memory-save.js'
 import { registerMemorySearchTool } from '../src/tools/memory-search.js'
 import { registerMemoryStatsTool } from '../src/tools/memory-stats.js'
+import { registerMemoryUpdateTool } from '../src/tools/memory-update.js'
 
 /** Mock McpServer that captures tool registrations */
 function createMockServer() {
@@ -232,5 +241,181 @@ describe('memory_cleanup tool', () => {
     const result = await handler({ olderThanDays: 60, dryRun: false })
 
     expect(result.content[0].text).toBe('Deleted 3 memories (not accessed in 60 days).')
+  })
+})
+
+describe('unified error handling', () => {
+  it('returns error response for MemoryNotFoundError on delete', async () => {
+    const testId = '550e8400-e29b-41d4-a716-446655440000'
+    const container = createMockContainer({
+      deleteMemory: {
+        execute: vi.fn().mockRejectedValue(new MemoryNotFoundError(testId)),
+      },
+    })
+    const server = createMockServer()
+    registerMemoryDeleteTool(server as unknown as McpServer, container)
+
+    const handler = server.tools.get('memory_delete')!.handler
+    const result = await handler({ id: testId })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe(`Error: Memory not found: ${testId}`)
+  })
+
+  it('returns error response for MemoryNotFoundError on update', async () => {
+    const testId = '550e8400-e29b-41d4-a716-446655440000'
+    const container = createMockContainer({
+      updateMemory: {
+        execute: vi.fn().mockRejectedValue(new MemoryNotFoundError(testId)),
+      },
+    })
+    const server = createMockServer()
+    registerMemoryUpdateTool(server as unknown as McpServer, container)
+
+    const handler = server.tools.get('memory_update')!.handler
+    const result = await handler({ id: testId, content: 'updated' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe(`Error: Memory not found: ${testId}`)
+  })
+
+  it('returns error response for EmbeddingFailedError on save', async () => {
+    const container = createMockContainer({
+      saveMemory: {
+        saveManual: vi.fn().mockRejectedValue(new EmbeddingFailedError('model unavailable')),
+      },
+    })
+    const server = createMockServer()
+    registerMemorySaveTool(server as unknown as McpServer, container)
+
+    const handler = server.tools.get('memory_save')!.handler
+    const result = await handler({ content: 'test', sessionId: 'sess-1' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe('Error: Embedding failed: model unavailable')
+  })
+
+  it('returns error response for EmbeddingFailedError on search', async () => {
+    const container = createMockContainer({
+      searchMemory: {
+        search: vi.fn().mockRejectedValue(new EmbeddingFailedError('timeout')),
+      },
+    })
+    const server = createMockServer()
+    registerMemorySearchTool(server as unknown as McpServer, container)
+
+    const handler = server.tools.get('memory_search')!.handler
+    const result = await handler({ query: 'test', limit: 5, allProjects: false })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe('Error: Embedding failed: timeout')
+  })
+
+  it('returns error response for StorageConnectionError on cleanup', async () => {
+    const container = createMockContainer({
+      cleanupMemory: {
+        execute: vi.fn().mockRejectedValue(new StorageConnectionError('connection refused')),
+      },
+    })
+    const server = createMockServer()
+    registerMemoryCleanupTool(server as unknown as McpServer, container)
+
+    const handler = server.tools.get('memory_cleanup')!.handler
+    const result = await handler({ olderThanDays: 30, dryRun: true })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe('Error: Storage connection error: connection refused')
+  })
+
+  it('returns internal error for unknown errors', async () => {
+    const container = createMockContainer({
+      deleteMemory: {
+        execute: vi.fn().mockRejectedValue(new TypeError('Cannot read properties of null')),
+      },
+    })
+    const server = createMockServer()
+    registerMemoryDeleteTool(server as unknown as McpServer, container)
+
+    const handler = server.tools.get('memory_delete')!.handler
+    const result = await handler({ id: '550e8400-e29b-41d4-a716-446655440000' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe('Internal error: Cannot read properties of null')
+  })
+
+  it('returns error response for parse errors on import', async () => {
+    const container = createMockContainer()
+    const server = createMockServer()
+    registerMemoryImportTool(server as unknown as McpServer, container)
+
+    const handler = server.tools.get('memory_import')!.handler
+    const result = await handler({ data: 'not-valid-json' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toMatch(/^Internal error:/)
+  })
+
+  it('returns error response for StorageConnectionError on list', async () => {
+    const container = createMockContainer({
+      listMemories: {
+        execute: vi.fn().mockRejectedValue(new StorageConnectionError('pool exhausted')),
+      },
+    })
+    const server = createMockServer()
+    registerMemoryListTool(server as unknown as McpServer, container)
+
+    const handler = server.tools.get('memory_list')!.handler
+    const result = await handler({ limit: 10, offset: 0 })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe('Error: Storage connection error: pool exhausted')
+  })
+
+  it('returns error response on stats failure', async () => {
+    const container = createMockContainer({
+      getStats: {
+        execute: vi.fn().mockRejectedValue(new StorageConnectionError('db down')),
+      },
+    })
+    const server = createMockServer()
+    registerMemoryStatsTool(server as unknown as McpServer, container)
+
+    const handler = server.tools.get('memory_stats')!.handler
+    const result = await handler()
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe('Error: Storage connection error: db down')
+  })
+
+  it('returns error response on export failure', async () => {
+    const container = createMockContainer({
+      exportMemory: {
+        execute: vi.fn().mockRejectedValue(new StorageConnectionError('timeout')),
+      },
+    })
+    const server = createMockServer()
+    registerMemoryExportTool(server as unknown as McpServer, container)
+
+    const handler = server.tools.get('memory_export')!.handler
+    const result = await handler()
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe('Error: Storage connection error: timeout')
+  })
+
+  it('returns error response on clear failure', async () => {
+    const container = createMockContainer({
+      clearMemory: {
+        execute: vi.fn().mockRejectedValue(new StorageConnectionError('permission denied')),
+      },
+    })
+    const server = createMockServer()
+    registerMemoryClearTool(server as unknown as McpServer, container)
+
+    const handler = server.tools.get('memory_clear')!.handler
+    const result = await handler()
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe('Error: Storage connection error: permission denied')
   })
 })


### PR DESCRIPTION
`handleToolError` ラッパーで全10ツールのエラーハンドリングを統一。MemoryNotFoundError等のドメインエラーをユーザーフレンドリーなレスポンスに変換。11件のエラーテスト追加。

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)