### PR TITLE
docs: パッケージ別詳細ドキュメント追加

### DIFF
--- a/docs/engineer/architecture.md
+++ b/docs/engineer/architecture.md
@@ -76,6 +76,13 @@ packages/
 └── hooks/             Claude Code Hooks連携
 ```
 
+各パッケージの詳細ドキュメント:
+- [core](packages/core.md) — エンティティ、インターフェース、ユースケース、定数
+- [embedding-onnx](packages/embedding-onnx.md) — モデル設定、実装詳細
+- [storage-postgres](packages/storage-postgres.md) — 接続設定、インデックス、検索の仕組み
+- [mcp-server](packages/mcp-server.md) — DIコンテナ、ツール一覧、設定
+- [hooks](packages/hooks.md) — SessionEndHandler、QAChunkingStrategy
+
 ## 依存方向
 
 ```

--- a/docs/engineer/packages/core.md
+++ b/docs/engineer/packages/core.md
@@ -1,0 +1,67 @@
+# @claude-memory/core
+
+ドメイン層。外部依存ゼロ。ビジネスロジックの中心。
+
+## エンティティ
+
+### Memory
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| id | string (UUID) | 一意識別子 |
+| content | string | 記憶のテキスト内容（空文字不可） |
+| embedding | number[] \| null | 384次元ベクトル。list/findById時はnull |
+| metadata | MemoryMetadata | セッションID、プロジェクトパス、タグ、ソース |
+| createdAt | Date | 作成日時 |
+| updatedAt | Date | 更新日時 |
+| lastAccessedAt | Date | 最終アクセス日時（検索ヒット時に更新） |
+
+### SearchResult
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| memory | Memory | 記憶本体 |
+| score | number | 検索スコア（0-1） |
+| matchType | 'keyword' \| 'vector' \| 'hybrid' | マッチ種別 |
+
+## インターフェース
+
+### EmbeddingProvider
+- `embed(text: string): Promise<number[]>` — 単一テキストをベクトル化
+- `embedBatch(texts: string[]): Promise<number[][]>` — バッチベクトル化（Promise.all並列）
+- `getDimension(): number` — ベクトル次元数を返す
+
+### StorageRepository
+- `save(memory)` — 保存（upsert）
+- `saveBatch(memories[])` — バッチ保存
+- `findById(id)` — ID検索（embedding=null）
+- `searchByKeyword(query, limit, filter?)` — キーワード検索（pg_bigm）
+- `searchByVector(embedding, limit, filter?)` — ベクトル検索（pgvector）
+- `list(options)` — 一覧取得（ページネーション）
+- `delete(id)` — 削除
+- `clear()` — 全削除
+- `getStats()` — 統計情報
+- `exportAll()` — 全件エクスポート
+- `deleteOlderThan(field, days)` — 古い記憶を削除
+- `countOlderThan(field, days)` — 古い記憶をカウント
+
+### ChunkingStrategy
+- `chunk(conversation: ConversationLog): Chunk[]` — 会話をチャンクに分割
+
+## ユースケース
+
+### SaveMemoryUseCase
+保存前に重複チェック（コサイン類似度 >= 0.95）。saveConversationではPromise.allで並列チェック。
+
+### SearchMemoryUseCase
+キーワード検索とベクトル検索を並列実行 → RRF (k=60) で統合 → 時間減衰（半減期30日）。
+
+### UpdateMemoryUseCase
+content変更時のみ再embedding。tag変更のみならembeddingは保持。
+
+## 定数
+
+| 定数 | 値 | 説明 |
+|------|-----|------|
+| SEARCH_DEFAULTS.rrfK | 60 | RRFパラメータ |
+| SEARCH_DEFAULTS.decayHalfLifeDays | 30 | 時間減衰の半減期 |
+| SEARCH_DEFAULTS.maxResults | 20 | デフォルト検索結果数 |
+| DEDUP_DEFAULTS.similarityThreshold | 0.95 | 重複判定閾値 |

--- a/docs/engineer/packages/embedding-onnx.md
+++ b/docs/engineer/packages/embedding-onnx.md
@@ -1,0 +1,24 @@
+# @claude-memory/embedding-onnx
+
+ONNX埋め込み実装。@huggingface/transformersでローカル推論。
+
+## OnnxEmbeddingProvider
+
+### 設定
+| オプション | デフォルト | 説明 |
+|-----------|----------|------|
+| modelName | intfloat/multilingual-e5-small | 埋め込みモデル |
+
+### 利用可能モデル
+| モデル | 次元 | サイズ |
+|--------|------|--------|
+| intfloat/multilingual-e5-small | 384 | ~100MB |
+| intfloat/multilingual-e5-base | 768 | ~300MB |
+| intfloat/multilingual-e5-large | 1024 | ~500MB |
+
+### 実装詳細
+- 遅延初期化: 初回embed時にモデルをダウンロード → `~/.cache/` にキャッシュ
+- プーリング: mean pooling
+- 正規化: L2 norm
+- バッチ処理: `Promise.all` で並列実行
+- Dockerイメージビルド時にwarmupでモデルをプリダウンロード

--- a/docs/engineer/packages/hooks.md
+++ b/docs/engineer/packages/hooks.md
@@ -1,0 +1,27 @@
+# @claude-memory/hooks
+
+Claude Code Hooks連携。PostSessionEndフックでセッション終了時に会話を自動保存。
+
+## SessionEndHandler
+会話ログ（JSONL）を読み取り、Q&Aペアに分割してDBに保存する。
+
+### 処理フロー
+1. JSOLNファイルを1行ずつパース
+2. 不正な行はスキップ（graceful degradation）
+3. QAChunkingStrategyでQ&Aペアに分割
+4. SaveMemoryUseCase.saveConversation()で保存
+
+## QAChunkingStrategy
+会話をQ&Aペアに分割するチャンキング戦略。
+
+### 設定
+| オプション | デフォルト | 説明 |
+|-----------|----------|------|
+| maxChunkChars | 1000 | チャンクの最大文字数 |
+
+### 分割ロジック
+1. 連続するuserメッセージ → Q部分
+2. 連続するassistantメッセージ → A部分
+3. `Q: {question}\nA: {answer}` 形式で結合
+4. maxChunkCharsを超えた場合は文境界で分割（日本語`。`、英語`.!?`）
+5. 単一文が上限を超える場合は文字数で強制分割

--- a/docs/engineer/packages/mcp-server.md
+++ b/docs/engineer/packages/mcp-server.md
@@ -1,0 +1,21 @@
+# @claude-memory/mcp-server
+
+MCPサーバー。全パッケージを束ねるエントリポイント。
+
+## DIコンテナ (createContainer)
+全ユースケースをインスタンス化し、依存を注入する。
+
+## ツール一覧
+10種のMCPツールを公開。詳細は [MCPツールリファレンス](../mcp-tools.md) を参照。
+
+## エラーハンドリング
+`handleToolError` ラッパーで全ツールのエラーを統一的に処理。MemoryError系はユーザーフレンドリーなメッセージに変換。
+
+## 設定 (AppConfig)
+| 設定 | 環境変数 | デフォルト |
+|------|---------|----------|
+| databaseUrl | DATABASE_URL | （必須） |
+| embeddingModel | EMBEDDING_MODEL | intfloat/multilingual-e5-small |
+| embeddingDimension | EMBEDDING_DIMENSION | 384 |
+| dbPoolSize | DB_POOL_SIZE | 10 |
+| logLevel | LOG_LEVEL | info |

--- a/docs/engineer/packages/storage-postgres.md
+++ b/docs/engineer/packages/storage-postgres.md
@@ -1,0 +1,30 @@
+# @claude-memory/storage-postgres
+
+PostgreSQL実装。Drizzle ORMでクエリ構築。
+
+## PostgresStorageRepository
+
+### 接続設定
+| オプション | デフォルト | 環境変数 | 説明 |
+|-----------|----------|---------|------|
+| connectionString | （必須） | DATABASE_URL | PostgreSQL接続URL |
+| maxConnections | 10 | DB_POOL_SIZE | コネクションプールサイズ |
+
+### インデックス
+| インデックス | 型 | 用途 |
+|-------------|-----|------|
+| idx_memories_vector | HNSW (vector_cosine_ops) | ベクトル近傍検索 |
+| idx_memories_bigm | GIN (gin_bigm_ops) | 日本語キーワード検索 |
+
+### キーワード検索の仕組み
+1. `LIKE '%query%'` でフィルタ（特殊文字はエスケープ）
+2. `bigm_similarity()` でスコア付け
+3. スコア降順でソート
+
+### ベクトル検索の仕組み
+1. `<=>` 演算子でコサイン距離を計算
+2. HNSW indexで高速近傍検索
+3. スコア = 1 - distance
+
+### lastAccessedAt
+検索ヒット時に `touchLastAccessed()` で自動更新。クリーンアップの判定基準に使用。


### PR DESCRIPTION
5パッケージの詳細ドキュメントを `docs/engineer/packages/` に追加。エンティティ、インターフェース、設定、実装詳細を網羅。

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)