### PR TITLE
perf: Dockerイメージサイズを54%削減（1.41GB→643MB）

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.git
+.github
+.claude
+.husky
+docs
+*.md
+.env
+.env.*
+.biome.json
+.oxlintrc.json
+.dependency-cruiser.cjs
+knip.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,30 @@ RUN pnpm --filter @claude-memory/embedding-onnx exec node -e " \
   }).catch(e => { console.error(e); process.exit(1); }) \
 "
 
+# Save built dist files
+RUN find packages -name 'dist' -type d | tar cf /tmp/dist.tar -T -
+
+# Reinstall production dependencies only (no devDeps)
+RUN rm -rf node_modules packages/*/node_modules
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts
+
+# Restore built dist files over the prod-only install
+RUN tar xf /tmp/dist.tar
+
+# Remove source files and test artifacts not needed at runtime
+RUN find packages -name 'src' -type d -exec rm -rf {} + 2>/dev/null; \
+    find packages -name 'tests' -type d -exec rm -rf {} + 2>/dev/null; \
+    find packages -name '*.test.ts' -delete 2>/dev/null; \
+    rm -rf packages/*/tsconfig.json packages/*/vitest.config.ts /tmp/dist.tar; \
+    true
+
 FROM node:22-slim AS runner
 
-RUN corepack enable && corepack prepare pnpm@10.8.1 --activate
-
 WORKDIR /app
-COPY --from=builder /app .
+COPY --from=builder /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml /app/.npmrc ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages ./packages
+# Copy ONNX model cache
+COPY --from=builder /root/.cache /root/.cache
 
 CMD ["node", "packages/mcp-server/dist/index.js"]


### PR DESCRIPTION
## Summary

- devDependenciesを排除（440→161パッケージ）
- src/tests/tsconfig等のソースファイルを削除
- runnerステージからcorepack setupを削除
- .dockerignoreを追加（ビルドコンテキスト削減）
- ONNXモデルキャッシュを明示的にコピー

## サイズ比較

| | Before | After |
|---|---|---|
| イメージサイズ | 1.41 GB | 643 MB |
| パッケージ数 | 440 | 161 |

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)