### PR TITLE
feat(mcp-server): 検索結果のキーワードハイライト

### DIFF
--- a/packages/mcp-server/src/tools/memory-search.ts
+++ b/packages/mcp-server/src/tools/memory-search.ts
@@ -7,6 +7,18 @@ import { handleToolError } from './error-handler.js'
 
 const SCORE_DECIMAL_PLACES = 4
 
+/**
+ * Wraps matched keywords with markdown bold markers for visibility.
+ * @param content - The content string to highlight within
+ * @param query - The search query to highlight
+ * @returns Content with matched keywords wrapped in ** markers
+ */
+const highlightKeyword = (content: string, query: string): string => {
+  if (!query) return content
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return content.replace(new RegExp(escaped, 'gi'), (match) => `**${match}**`)
+}
+
 export function registerMemorySearchTool(
   server: McpServer,
   container: Container,
@@ -56,9 +68,13 @@ export function registerMemorySearchTool(
 
         const formatted = results
           .map((r, i) => {
+            const content =
+              r.matchType !== 'vector'
+                ? highlightKeyword(r.memory.content, args.query)
+                : r.memory.content
             const lines = [
               `[${i + 1}] matchType=${r.matchType} score=${r.score.toFixed(SCORE_DECIMAL_PLACES)}`,
-              r.memory.content,
+              content,
             ]
             return lines.join('\n')
           })

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -178,6 +178,36 @@ describe('memory_search tool', () => {
     expect(result.content[0].text).toMatch(/^No memories found\./)
   })
 
+  it('highlights keyword in search results for keyword/hybrid matches', async () => {
+    const container = createMockContainer({
+      searchMemory: {
+        search: vi.fn().mockResolvedValue([
+          {
+            matchType: 'keyword',
+            score: 0.8,
+            memory: { content: 'TypeScript is a typed language' },
+          },
+          {
+            matchType: 'vector',
+            score: 0.7,
+            memory: { content: 'TypeScript is great' },
+          },
+        ]),
+      },
+    })
+    const server = createMockServer()
+    const logger = createMockLogger()
+    registerMemorySearchTool(server as unknown as McpServer, container, logger)
+
+    const handler = server.tools.get('memory_search')!.handler
+    const result = await handler({ query: 'TypeScript', limit: 5, allProjects: false })
+
+    // keyword match should have bold highlighting
+    expect(result.content[0].text).toContain('**TypeScript**')
+    // vector-only match should NOT have highlighting
+    expect(result.content[0].text).toMatch(/\[2\].*\nTypeScript is great/)
+  })
+
   it('returns formatted results when memories exist', async () => {
     const container = createMockContainer({
       searchMemory: {


### PR DESCRIPTION
keyword/hybridマッチの結果でクエリ文字列を **太字** でハイライト。vector-onlyの結果はハイライトしない。

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)