### PR TITLE
feat: SessionStartフックで自動記憶検索

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ docker compose ps
     }
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "command": "docker exec claude-memory-mcp-server-1 node packages/mcp-server/dist/session-start.js"
+      }
+    ],
     "PostSessionEnd": [
       {
         "command": "docker exec claude-memory-mcp-server-1 node packages/hooks/dist/index.js"

--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,10 @@
     "packages/*": {
       "entry": ["src/index.ts"],
       "project": ["src/**/*.ts"]
+    },
+    "packages/mcp-server": {
+      "entry": ["src/index.ts", "src/session-start.ts"],
+      "project": ["src/**/*.ts"]
     }
   },
   "ignore": ["**/*.test.ts", "scripts/**"],

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,2 +1,3 @@
 export { QAChunkingStrategy } from './qa-chunking-strategy.js'
 export { SessionEndHandler } from './session-end-handler.js'
+export { SessionStartHandler } from './session-start-handler.js'

--- a/packages/hooks/src/session-start-handler.ts
+++ b/packages/hooks/src/session-start-handler.ts
@@ -1,0 +1,30 @@
+import type { SearchFilter, SearchResult } from '@claude-memory/core'
+
+const SESSION_START_SEARCH_LIMIT = 5
+
+interface SearchCapable {
+  search(query: string, limit: number, filter?: SearchFilter): Promise<SearchResult[]>
+}
+
+export class SessionStartHandler {
+  constructor(private readonly searchUseCase: SearchCapable) {}
+
+  async handle(projectPath?: string): Promise<string> {
+    const filter: SearchFilter | undefined = projectPath ? { projectPath } : undefined
+    const results = await this.searchUseCase.search(
+      'project context',
+      SESSION_START_SEARCH_LIMIT,
+      filter,
+    )
+
+    if (results.length === 0) {
+      return 'No relevant memories found.'
+    }
+
+    const formatted = results
+      .map((r, i) => `[${i + 1}] (score: ${r.score.toFixed(2)}) ${r.memory.content}`)
+      .join('\n\n')
+
+    return `## Previous session context:\n\n${formatted}`
+  }
+}

--- a/packages/hooks/tests/session-start-handler.test.ts
+++ b/packages/hooks/tests/session-start-handler.test.ts
@@ -1,0 +1,85 @@
+import type { SearchFilter, SearchResult } from '@claude-memory/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SessionStartHandler } from '../src/session-start-handler.js'
+
+function createMemory(id: string, content: string): SearchResult {
+  return {
+    memory: {
+      id,
+      content,
+      embedding: null,
+      metadata: { sessionId: 'sess-1', source: 'auto' },
+      createdAt: new Date('2026-04-01T00:00:00Z'),
+      updatedAt: new Date('2026-04-01T00:00:00Z'),
+      lastAccessedAt: new Date('2026-04-01T00:00:00Z'),
+    },
+    score: 0.85,
+    matchType: 'hybrid',
+  }
+}
+
+describe('SessionStartHandler', () => {
+  let mockSearchUseCase: {
+    search: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    mockSearchUseCase = {
+      search: vi.fn(),
+    }
+  })
+
+  it('should return formatted memories when results exist', async () => {
+    mockSearchUseCase.search.mockResolvedValue([
+      createMemory('1', 'Project uses TypeScript'),
+      createMemory('2', 'Database is PostgreSQL'),
+    ])
+
+    const handler = new SessionStartHandler(mockSearchUseCase)
+    const result = await handler.handle('/my/project')
+
+    expect(result).toContain('## Previous session context:')
+    expect(result).toContain('[1]')
+    expect(result).toContain('Project uses TypeScript')
+    expect(result).toContain('[2]')
+    expect(result).toContain('Database is PostgreSQL')
+  })
+
+  it('should return no-results message when no memories found', async () => {
+    mockSearchUseCase.search.mockResolvedValue([])
+
+    const handler = new SessionStartHandler(mockSearchUseCase)
+    const result = await handler.handle('/my/project')
+
+    expect(result).toBe('No relevant memories found.')
+  })
+
+  it('should pass projectPath as filter when provided', async () => {
+    mockSearchUseCase.search.mockResolvedValue([])
+
+    const handler = new SessionStartHandler(mockSearchUseCase)
+    await handler.handle('/my/project')
+
+    expect(mockSearchUseCase.search).toHaveBeenCalledWith('project context', 5, {
+      projectPath: '/my/project',
+    })
+  })
+
+  it('should search without filter when projectPath is undefined', async () => {
+    mockSearchUseCase.search.mockResolvedValue([])
+
+    const handler = new SessionStartHandler(mockSearchUseCase)
+    await handler.handle()
+
+    expect(mockSearchUseCase.search).toHaveBeenCalledWith('project context', 5, undefined)
+  })
+
+  it('should include score in formatted output', async () => {
+    mockSearchUseCase.search.mockResolvedValue([createMemory('1', 'Some memory')])
+
+    const handler = new SessionStartHandler(mockSearchUseCase)
+    const result = await handler.handle()
+
+    expect(result).toContain('(score: 0.85)')
+  })
+})

--- a/packages/mcp-server/src/session-start.ts
+++ b/packages/mcp-server/src/session-start.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { SearchMemoryUseCase } from '@claude-memory/core'
+import { OnnxEmbeddingProvider } from '@claude-memory/embedding-onnx'
+import { SessionStartHandler } from '@claude-memory/hooks'
+import { PostgresStorageRepository } from '@claude-memory/storage-postgres'
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    console.error('DATABASE_URL is required')
+    process.exit(1)
+  }
+
+  const storage = new PostgresStorageRepository(databaseUrl)
+  const embedding = new OnnxEmbeddingProvider({
+    modelName: process.env.EMBEDDING_MODEL ?? 'intfloat/multilingual-e5-small',
+  })
+
+  try {
+    const searchUseCase = new SearchMemoryUseCase(storage, embedding)
+    const handler = new SessionStartHandler(searchUseCase)
+    const projectPath = process.env.PROJECT_PATH || process.cwd()
+    const output = await handler.handle(projectPath)
+    console.log(output)
+  } finally {
+    await storage.close()
+  }
+}
+
+main().catch((e) => {
+  console.error(e.message)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- `SessionStartHandler` をhooksパッケージに追加（依存方向を維持）
- `session-start.ts` エントリポイントをmcp-serverに配置
- セッション開始時に関連記憶を自動検索し、前回のコンテキストを出力
- READMEのsettings.json例にSessionStartフック追加
- 5件のテスト追加

### 設定方法

```json
{
  "hooks": {
    "SessionStart": [{
      "command": "docker exec claude-memory-mcp-server-1 node packages/mcp-server/dist/session-start.js"
    }]
  }
}
```

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)