### PR TITLE
docs: add terraform infrastructure management guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@
 
 ## プロジェクト固有の指示
 
+- **セッション開始時に `memory_search` で過去の文脈・設計判断・好みを必ず検索してから作業を始める**
+- 判断に迷ったらまず `memory_search` で過去の合意を確認する（ドキュメント配置、技術選定など）
 - コミット時は Conventional Commits に従う（scope: core, embedding-onnx, storage-postgres, mcp-server, hooks）
 - PRは必ず関連Issueを紐付ける
 - 型定義変更時はJSDocも同時に更新する
@@ -31,6 +33,7 @@
 | MCPツール | [docs/generated/mcp-tools.md](docs/generated/mcp-tools.md) | 全10ツールの詳細仕様（自動生成） |
 | 依存関係図 | [docs/generated/dependency-graph.svg](docs/generated/dependency-graph.svg) | パッケージ依存関係の可視化（自動生成） |
 | DBスキーマ | [docs/generated/schema/](docs/generated/schema/) | データベーススキーマ定義（自動生成） |
+| インフラ管理 | [docs/engineer/infrastructure.md](docs/engineer/infrastructure.md) | Terraform管理対象、セットアップ、plan/apply手順 |
 | セキュリティ | [docs/engineer/security.md](docs/engineer/security.md) | SQLインジェクション対策、認証情報管理 |
 | ADR | [docs/adr/](docs/adr/) | 設計判断記録 |
 

--- a/docs/engineer/infrastructure.md
+++ b/docs/engineer/infrastructure.md
@@ -1,0 +1,69 @@
+# インフラ管理（Terraform）
+
+GitHub リポジトリの設定を Terraform で管理している。
+
+## 管理対象
+
+| リソース | ファイル | 内容 |
+|----------|----------|------|
+| リポジトリ設定 | `infra/github/main.tf` | visibility, マージ戦略, topics |
+| ブランチ保護 | `infra/github/branch-protection.tf` | PRレビュー, CI必須チェック (lint, test) |
+| ラベル | `infra/github/labels.tf` | epic, task, story, bug, subtask |
+
+## 前提条件
+
+- Terraform CLI >= 1.14.0
+- GitHub Personal Access Token（`repo` の Full control 権限）
+
+### トークンの作成手順
+
+1. GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)
+2. `Generate new token (classic)` をクリック
+3. スコープ: `repo`（Full control of private repositories）にチェック
+4. 生成されたトークンを控える（再表示不可）
+
+## セットアップ
+
+```bash
+cd infra/github
+terraform init
+```
+
+## 実行手順
+
+### 差分確認（plan）
+
+```bash
+terraform plan -var="github_token=ghp_xxxxx"
+```
+
+### 適用（apply）
+
+```bash
+terraform apply -var="github_token=ghp_xxxxx"
+```
+
+> トークンをシェル履歴に残したくない場合は環境変数を使う:
+>
+> ```bash
+> export TF_VAR_github_token="ghp_xxxxx"
+> terraform plan
+> terraform apply
+> ```
+
+## tfstate の管理方針
+
+現在は **ローカル管理**（`terraform.tfstate` をリポジトリに含む）。
+
+- このリポジトリは個人プロジェクトであり、同時編集のリスクがないためローカル管理で十分
+- チーム開発に移行する場合は S3 + DynamoDB 等のリモートバックエンドを検討する
+
+## CI/CD からの自動適用
+
+現時点では未導入。手動で `plan` → `apply` を実行する運用。
+
+導入する場合の検討事項:
+
+- GitHub Actions で PR 時に `terraform plan` を自動実行
+- main マージ時に `terraform apply` を自動実行
+- トークンは GitHub Actions Secrets に格納


### PR DESCRIPTION
## Summary
- `docs/engineer/infrastructure.md` を新規作成（Terraform管理対象、セットアップ、plan/apply手順、tfstate方針）
- `CLAUDE.md` にドキュメントリンク追加 + セッション開始時のmemory_search指示を明記

Closes #70

## Test plan
- [ ] ドキュメントの手順に従って `terraform init` → `terraform plan` が実行できること
- [ ] CLAUDE.mdのリンクが正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)