### PR TITLE
fix(storage-postgres): convert Date to ISO string in cleanup queries

### DIFF
--- a/packages/storage-postgres/src/postgres-storage-repository.ts
+++ b/packages/storage-postgres/src/postgres-storage-repository.ts
@@ -438,7 +438,7 @@ export class PostgresStorageRepository implements StorageRepository {
     cutoff.setDate(cutoff.getDate() - olderThanDays)
     const result = await this.db
       .delete(memories)
-      .where(sql`${col} < ${cutoff}`)
+      .where(sql`${col} < ${cutoff.toISOString()}`)
       .returning({ id: memories.id })
     return result.length
   }
@@ -459,7 +459,7 @@ export class PostgresStorageRepository implements StorageRepository {
     const result = await this.db
       .select({ count: sql<number>`COUNT(*)::int` })
       .from(memories)
-      .where(sql`${col} < ${cutoff}`)
+      .where(sql`${col} < ${cutoff.toISOString()}`)
     return result[0]?.count ?? 0
   }
 


### PR DESCRIPTION
## Summary

- `deleteOlderThan` / `countOlderThan` で `Date` オブジェクトを `sql` テンプレートに直接渡していたため、`lastAccessedOlderThan` 戦略の cleanup が実行時エラーになっていた
- `.toISOString()` で文字列に変換するよう修正

Closes #168

## Test plan

- [x] `pnpm --filter @claude-memory/storage-postgres test` — 36 tests passed
- [x] `pnpm test` — 全パッケージ全テスト通過
- [ ] 次セッションで `memory_cleanup` の `lastAccessedOlderThan` 戦略を dryRun で実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)