### PR TITLE
refactor(hooks): convert handlers and chunking strategy to factory functions

### DIFF
--- a/docs/adr/0009-infrastructure-adapter-factory-functions.md
+++ b/docs/adr/0009-infrastructure-adapter-factory-functions.md
@@ -2,7 +2,7 @@
 
 ## ステータス
 
-採用（ADR-0008 を拡張）
+採用（ADR-0008 を拡張）。[ADR-0010](./0010-hooks-factory-functions.md) で hooks 層まで最終的に拡張し、class-to-factory 移行完了。
 
 ## コンテキスト
 

--- a/docs/adr/0010-hooks-factory-functions.md
+++ b/docs/adr/0010-hooks-factory-functions.md
@@ -1,0 +1,65 @@
+# ADR-0010: hooks 層を factory function 化し、class-to-factory 移行を完了する
+
+## ステータス
+
+採用（ADR-0008 / ADR-0009 の最終段）
+
+## コンテキスト
+
+- [ADR-0008](./0008-use-case-factory-functions.md): core/use-cases を factory function 化
+- [ADR-0009](./0009-infrastructure-adapter-factory-functions.md): infrastructure adapter（embedding-onnx / storage-postgres）を factory function 化
+
+残る class は **hooks パッケージの 3 つ**:
+
+| class | 性質 |
+|---|---|
+| `SessionStartHandler` | Claude Code の SessionStart フック用の interface 層 wrapper |
+| `SessionEndHandler` | SessionEnd フック用の interface 層 wrapper |
+| `QAChunkingStrategy implements ChunkingStrategy` | core の ChunkingStrategy を実装する adapter |
+
+これらも全て:
+
+- 継承なし
+- `instanceof` なし
+- state は closure で表現可能
+- ADR-0008 の論拠（継承しない class は `final` が無いため誤ったシグナルを送る）がそのまま当てはまる
+
+## 決定
+
+hooks パッケージの 3 class も factory function に統一する。
+
+- `SessionStartHandler` → `defineSessionStartHandler(searchUseCase): SessionStartHandler`
+- `SessionEndHandler` → `defineSessionEndHandler(saveUseCase): SessionEndHandler`
+- `QAChunkingStrategy` → `defineQAChunkingStrategy(options?): ChunkingStrategy`
+
+これにより **core を import する全 module が factory function で統一** され、`errors/memory-error.ts` のみが唯一の class 例外となる（ADR-0008 参照）。
+
+### 付随する清掃
+
+`SessionEndHandler` のコンストラクタは `chunking: ChunkingStrategy` を受け取っていたが、`handle()` 内で使われていない **死にパラメータ** だった（チャンキングは `saveUseCase.saveConversation` 内で行われるため）。factory 化にあたりこの嘘を除去し、`defineSessionEndHandler(saveUseCase)` のみを受け取る形に変更する。
+
+## 理由
+
+- 3 度目の同じ議論を避けるため、コードベース全体を一括で統一する
+- "interface 層 wrapper" と "infrastructure adapter" の境界線に悩む必要をなくす（どちらも factory）
+- `SessionEndHandler` の死にパラメータは signature の嘘であり、refactor ついでに消すのが誠実
+
+## 影響
+
+- `packages/hooks/src/session-start-handler.ts` を factory function に書き換え
+- `packages/hooks/src/session-end-handler.ts` を factory function に書き換え
+  - `chunking` 死にパラメータを削除
+  - private `parseLog` を module-level 関数に移動
+- `packages/hooks/src/qa-chunking-strategy.ts` を factory function に書き換え
+  - private `extractQAPairs` / `splitChunk` / `splitIntoSentences` を module-level pure 関数に移動
+- `packages/hooks/src/index.ts` の re-export を更新
+- consumer 更新:
+  - `packages/mcp-server/src/session-start.ts` — `defineSessionStartHandler` に置換
+  - `packages/mcp-server/src/session-end.ts` — `defineSessionEndHandler(saveUseCase)` に置換（chunking 削除）
+  - `packages/mcp-server/src/container.ts` — `defineQAChunkingStrategy()` に置換
+- test 更新（hooks の 3 ファイル、19 テスト全て緑）
+- `packages/hooks/CLAUDE.md` の「主要クラス」を「主要 factory」テーブルに変更
+
+## 完了宣言
+
+本 ADR 採用をもって、`packages/core/src/errors/memory-error.ts` を除く全ての source code が factory function 規約で統一される。今後 core を import する新 module は factory function で実装すること。`extends Error` 等、継承が本質的機能となるケースのみ class を許容する。

--- a/packages/hooks/CLAUDE.md
+++ b/packages/hooks/CLAUDE.md
@@ -9,13 +9,15 @@
 - 依存先: `@claude-memory/core`（インターフェースと型のみ）
 - 依存元: `mcp-server`
 
-## 主要クラス
+## 主要 factory
 
-| クラス | ファイル | 役割 |
-|--------|---------|------|
-| `SessionStartHandler` | `src/session-start-handler.ts` | セッション開始時に関連記憶を検索・注入 |
-| `SessionEndHandler` | `src/session-end-handler.ts` | セッション終了時に会話を記憶として保存 |
-| `QAChunkingStrategy` | `src/qa-chunking-strategy.ts` | 会話を Q&A ペアに分割（ChunkingStrategy 実装） |
+ADR-0008 / ADR-0009 に従い、全て factory function で提供する（class は不使用）。
+
+| factory | 戻り値型 | ファイル | 役割 |
+|---------|---------|---------|------|
+| `defineSessionStartHandler(searchUseCase)` | `SessionStartHandler` | `src/session-start-handler.ts` | セッション開始時に関連記憶を検索・注入 |
+| `defineSessionEndHandler(saveUseCase)` | `SessionEndHandler` | `src/session-end-handler.ts` | セッション終了時に会話を記憶として保存 |
+| `defineQAChunkingStrategy(options?)` | `ChunkingStrategy` | `src/qa-chunking-strategy.ts` | 会話を Q&A ペアに分割（ChunkingStrategy 実装） |
 
 ## コマンド
 

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,3 +1,6 @@
-export { QAChunkingStrategy } from './qa-chunking-strategy.js'
-export { SessionEndHandler } from './session-end-handler.js'
-export { SessionStartHandler } from './session-start-handler.js'
+export {
+  defineQAChunkingStrategy,
+  type QAChunkingOptions,
+} from './qa-chunking-strategy.js'
+export { defineSessionEndHandler, type SessionEndHandler } from './session-end-handler.js'
+export { defineSessionStartHandler, type SessionStartHandler } from './session-start-handler.js'

--- a/packages/hooks/src/qa-chunking-strategy.ts
+++ b/packages/hooks/src/qa-chunking-strategy.ts
@@ -6,113 +6,104 @@ const QA_PREFIX_ASSISTANT = '\nA: '
 /** 文末句読点で分割する正規表現（日本語・英語対応） */
 const SENTENCE_BOUNDARY_REGEX = /[^。.!！?？\n]+[。.!！?？\n]?/g
 
-interface QAChunkingOptions {
+export interface QAChunkingOptions {
   maxChunkChars?: number
 }
 
-/** 会話をQ&Aペアのチャンクに分割するストラテジ。 */
-export class QAChunkingStrategy implements ChunkingStrategy {
-  private readonly maxChunkChars: number
+function extractQAPairs(conversation: ConversationLog): Chunk[] {
+  const chunks: Chunk[] = []
+  const messages = conversation.messages
+  let i = 0
 
-  /**
-   * QAChunkingStrategyの新しいインスタンスを生成する。
-   * @param options - チャンク最大文字数のオプション設定
-   */
-  constructor(options?: QAChunkingOptions) {
-    this.maxChunkChars = options?.maxChunkChars ?? DEFAULT_MAX_CHUNK_CHARS
-  }
-
-  /**
-   * 会話ログをQ&Aペアのチャンクに分割し、超過チャンクを分割する。
-   * @param conversation - チャンク化する会話ログ
-   * @returns embeddingと保存に適したチャンクの配列
-   */
-  chunk(conversation: ConversationLog): Chunk[] {
-    const rawChunks = this.extractQAPairs(conversation)
-    const result: Chunk[] = []
-
-    for (const chunk of rawChunks) {
-      if (chunk.content.length <= this.maxChunkChars) {
-        result.push(chunk)
-      } else {
-        result.push(...this.splitChunk(chunk))
-      }
+  while (i < messages.length) {
+    const userParts: string[] = []
+    while (i < messages.length && messages[i]!.role === 'user') {
+      userParts.push(messages[i]!.content)
+      i++
     }
 
-    return result
-  }
-
-  private extractQAPairs(conversation: ConversationLog): Chunk[] {
-    const chunks: Chunk[] = []
-    const messages = conversation.messages
-    let i = 0
-
-    while (i < messages.length) {
-      const userParts: string[] = []
-      while (i < messages.length && messages[i]!.role === 'user') {
-        userParts.push(messages[i]!.content)
-        i++
-      }
-
-      const assistantParts: string[] = []
-      while (i < messages.length && messages[i]!.role === 'assistant') {
-        assistantParts.push(messages[i]!.content)
-        i++
-      }
-
-      if (userParts.length > 0 && assistantParts.length > 0) {
-        chunks.push({
-          content: `${QA_PREFIX_USER}${userParts.join('\n')}${QA_PREFIX_ASSISTANT}${assistantParts.join('\n')}`,
-          metadata: {
-            sessionId: conversation.sessionId,
-            projectPath: conversation.projectPath,
-            source: 'auto',
-          },
-        })
-      }
+    const assistantParts: string[] = []
+    while (i < messages.length && messages[i]!.role === 'assistant') {
+      assistantParts.push(messages[i]!.content)
+      i++
     }
-    return chunks
+
+    if (userParts.length > 0 && assistantParts.length > 0) {
+      chunks.push({
+        content: `${QA_PREFIX_USER}${userParts.join('\n')}${QA_PREFIX_ASSISTANT}${assistantParts.join('\n')}`,
+        metadata: {
+          sessionId: conversation.sessionId,
+          projectPath: conversation.projectPath,
+          source: 'auto',
+        },
+      })
+    }
   }
+  return chunks
+}
 
-  private splitChunk(chunk: Chunk): Chunk[] {
-    const text = chunk.content
-    const sentences = this.splitIntoSentences(text)
-    const result: Chunk[] = []
-    let current = ''
+function splitIntoSentences(text: string): string[] {
+  // Split on sentence-ending punctuation (Japanese and English)
+  // Keep the delimiter attached to the preceding text
+  return text.match(SENTENCE_BOUNDARY_REGEX) ?? [text]
+}
 
-    for (const sentence of sentences) {
-      if (sentence.length > this.maxChunkChars) {
-        // Single sentence exceeds limit — force split by character
-        if (current.length > 0) {
-          result.push({ content: current.trim(), metadata: chunk.metadata })
-          current = ''
-        }
-        for (let j = 0; j < sentence.length; j += this.maxChunkChars) {
-          const slice = sentence.slice(j, j + this.maxChunkChars)
-          result.push({ content: slice, metadata: chunk.metadata })
-        }
-        continue
-      }
+function splitChunk(chunk: Chunk, maxChunkChars: number): Chunk[] {
+  const sentences = splitIntoSentences(chunk.content)
+  const result: Chunk[] = []
+  let current = ''
 
-      const joined = current.length > 0 ? `${current} ${sentence}` : sentence
-      if (joined.length > this.maxChunkChars) {
+  for (const sentence of sentences) {
+    if (sentence.length > maxChunkChars) {
+      // Single sentence exceeds limit — force split by character
+      if (current.length > 0) {
         result.push({ content: current.trim(), metadata: chunk.metadata })
-        current = sentence
-      } else {
-        current = joined
+        current = ''
       }
+      for (let j = 0; j < sentence.length; j += maxChunkChars) {
+        const slice = sentence.slice(j, j + maxChunkChars)
+        result.push({ content: slice, metadata: chunk.metadata })
+      }
+      continue
     }
 
-    if (current.trim().length > 0) {
+    const joined = current.length > 0 ? `${current} ${sentence}` : sentence
+    if (joined.length > maxChunkChars) {
       result.push({ content: current.trim(), metadata: chunk.metadata })
+      current = sentence
+    } else {
+      current = joined
     }
-
-    return result
   }
 
-  private splitIntoSentences(text: string): string[] {
-    // Split on sentence-ending punctuation (Japanese and English)
-    // Keep the delimiter attached to the preceding text
-    return text.match(SENTENCE_BOUNDARY_REGEX) ?? [text]
+  if (current.trim().length > 0) {
+    result.push({ content: current.trim(), metadata: chunk.metadata })
+  }
+
+  return result
+}
+
+/**
+ * 会話を Q&A ペアのチャンクに分割する ChunkingStrategy を生成する。
+ * @param options - チャンク最大文字数のオプション設定
+ */
+export function defineQAChunkingStrategy(options?: QAChunkingOptions): ChunkingStrategy {
+  const maxChunkChars = options?.maxChunkChars ?? DEFAULT_MAX_CHUNK_CHARS
+
+  return {
+    chunk(conversation: ConversationLog): Chunk[] {
+      const rawChunks = extractQAPairs(conversation)
+      const result: Chunk[] = []
+
+      for (const c of rawChunks) {
+        if (c.content.length <= maxChunkChars) {
+          result.push(c)
+        } else {
+          result.push(...splitChunk(c, maxChunkChars))
+        }
+      }
+
+      return result
+    },
   }
 }

--- a/packages/hooks/src/session-end-handler.ts
+++ b/packages/hooks/src/session-end-handler.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import type { ChunkingStrategy, ConversationLog, ConversationMessage } from '@claude-memory/core'
+import type { ConversationLog, ConversationMessage } from '@claude-memory/core'
 
 interface SaveConversationCapable {
   saveConversation(log: ConversationLog): Promise<void>
@@ -20,62 +20,64 @@ interface RawLogEntry {
 }
 
 /** セッション終了時に会話ログをQ&Aチャンクに変換してメモリとして保存するハンドラ。 */
-export class SessionEndHandler {
-  /**
-   * SessionEndHandlerの新しいインスタンスを生成する。
-   * @param chunking - 会話をチャンクに分割するストラテジ
-   * @param saveUseCase - 会話ログを永続化するユースケース
-   */
-  constructor(
-    private readonly chunking: ChunkingStrategy,
-    private readonly saveUseCase: SaveConversationCapable,
-  ) {}
-
+export interface SessionEndHandler {
   /**
    * 会話ログファイルを読み込み、チャンク化してメモリとして保存する。
    * @param conversationLogPath - JSONL形式の会話ログファイルのパス
    * @param sessionId - セッションの一意識別子
    * @param projectPath - メモリのスコープを絞るプロジェクトパス（省略可）
-   * @returns 全チャンクの保存完了時に解決するPromise
    */
-  async handle(
-    conversationLogPath: string,
-    sessionId: string,
-    projectPath?: string,
-  ): Promise<void> {
-    const messages = this.parseLog(conversationLogPath)
-    const log: ConversationLog = { sessionId, projectPath, messages }
-    await this.saveUseCase.saveConversation(log)
-  }
+  handle(conversationLogPath: string, sessionId: string, projectPath?: string): Promise<void>
+}
 
-  private parseLog(filePath: string): ConversationMessage[] {
-    const content = readFileSync(filePath, 'utf-8').trim()
-    if (!content) return []
+function parseLog(filePath: string): ConversationMessage[] {
+  const content = readFileSync(filePath, 'utf-8').trim()
+  if (!content) return []
 
-    const messages: ConversationMessage[] = []
-    for (const line of content.split('\n')) {
-      try {
-        const entry = JSON.parse(line) as RawLogEntry
-        if (entry.type !== 'user' && entry.type !== 'assistant') continue
-        if (!entry.message) continue
+  const messages: ConversationMessage[] = []
+  for (const line of content.split('\n')) {
+    try {
+      const entry = JSON.parse(line) as RawLogEntry
+      if (entry.type !== 'user' && entry.type !== 'assistant') continue
+      if (!entry.message) continue
 
-        const role = entry.message.role
-        const rawContent = entry.message.content
-        const text =
-          typeof rawContent === 'string'
-            ? rawContent
-            : rawContent
-                .filter((b) => b.type === 'text' && b.text)
-                .map((b) => b.text)
-                .join('\n')
+      const role = entry.message.role
+      const rawContent = entry.message.content
+      const text =
+        typeof rawContent === 'string'
+          ? rawContent
+          : rawContent
+              .filter((b) => b.type === 'text' && b.text)
+              .map((b) => b.text)
+              .join('\n')
 
-        if (role && text) {
-          messages.push({ role, content: text, timestamp: new Date(entry.timestamp) })
-        }
-      } catch {
-        // skip malformed lines
+      if (role && text) {
+        messages.push({ role, content: text, timestamp: new Date(entry.timestamp) })
       }
+    } catch {
+      // skip malformed lines
     }
-    return messages
+  }
+  return messages
+}
+
+/**
+ * セッション終了時ハンドラを生成する。
+ *
+ * チャンキングは `saveUseCase.saveConversation` 内部で行われるため、
+ * ここでは ChunkingStrategy を受け取らない。
+ * @param saveUseCase - 会話ログを永続化するユースケース
+ */
+export function defineSessionEndHandler(saveUseCase: SaveConversationCapable): SessionEndHandler {
+  return {
+    async handle(
+      conversationLogPath: string,
+      sessionId: string,
+      projectPath?: string,
+    ): Promise<void> {
+      const messages = parseLog(conversationLogPath)
+      const log: ConversationLog = { sessionId, projectPath, messages }
+      await saveUseCase.saveConversation(log)
+    },
   }
 }

--- a/packages/hooks/src/session-start-handler.ts
+++ b/packages/hooks/src/session-start-handler.ts
@@ -6,34 +6,38 @@ interface SearchCapable {
 }
 
 /** セッション開始時に関連メモリを検索してコンテキスト再現用にフォーマットするハンドラ。 */
-export class SessionStartHandler {
-  /**
-   * SessionStartHandlerの新しいインスタンスを生成する。
-   * @param searchUseCase - メモリを検索するユースケース
-   */
-  constructor(private readonly searchUseCase: SearchCapable) {}
-
+export interface SessionStartHandler {
   /**
    * 関連メモリを検索し、フォーマットされたコンテキスト文字列を返す。
    * @param projectPath - 検索スコープを絞るプロジェクトパス（省略可）
    * @returns 関連メモリのフォーマット済み文字列、または結果なしメッセージ
    */
-  async handle(projectPath?: string): Promise<string> {
-    const filter: SearchFilter | undefined = projectPath ? { projectPath } : undefined
-    const results = await this.searchUseCase.search(
-      'project context',
-      SESSION_START_SEARCH_LIMIT,
-      filter,
-    )
+  handle(projectPath?: string): Promise<string>
+}
 
-    if (results.length === 0) {
-      return 'No relevant memories found.'
-    }
+/**
+ * セッション開始時ハンドラを生成する。
+ * @param searchUseCase - メモリを検索するユースケース
+ */
+export function defineSessionStartHandler(searchUseCase: SearchCapable): SessionStartHandler {
+  return {
+    async handle(projectPath?: string): Promise<string> {
+      const filter: SearchFilter | undefined = projectPath ? { projectPath } : undefined
+      const results = await searchUseCase.search(
+        'project context',
+        SESSION_START_SEARCH_LIMIT,
+        filter,
+      )
 
-    const formatted = results
-      .map((r, i) => `[${i + 1}] (score: ${r.score.toFixed(2)}) ${r.memory.content}`)
-      .join('\n\n')
+      if (results.length === 0) {
+        return 'No relevant memories found.'
+      }
 
-    return `## Previous session context:\n\n${formatted}`
+      const formatted = results
+        .map((r, i) => `[${i + 1}] (score: ${r.score.toFixed(2)}) ${r.memory.content}`)
+        .join('\n\n')
+
+      return `## Previous session context:\n\n${formatted}`
+    },
   }
 }

--- a/packages/hooks/tests/qa-chunking-strategy.test.ts
+++ b/packages/hooks/tests/qa-chunking-strategy.test.ts
@@ -1,9 +1,9 @@
 import type { ConversationLog } from '@claude-memory/core'
 import { describe, expect, it } from 'vitest'
-import { QAChunkingStrategy } from '../src/qa-chunking-strategy.js'
+import { defineQAChunkingStrategy } from '../src/qa-chunking-strategy.js'
 
 describe('QAChunkingStrategy', () => {
-  const strategy = new QAChunkingStrategy()
+  const strategy = defineQAChunkingStrategy()
 
   it('should create Q&A pairs from user-assistant message pairs', () => {
     const log: ConversationLog = {
@@ -85,7 +85,7 @@ describe('QAChunkingStrategy', () => {
         { role: 'assistant', content: longAnswer, timestamp: new Date() },
       ],
     }
-    const strategy = new QAChunkingStrategy({ maxChunkChars: 500 })
+    const strategy = defineQAChunkingStrategy({ maxChunkChars: 500 })
     const chunks = strategy.chunk(log)
     expect(chunks.length).toBeGreaterThan(1)
     for (const chunk of chunks) {
@@ -113,7 +113,7 @@ describe('QAChunkingStrategy', () => {
       ],
     }
     // Set limit so that ~2-3 sentences fit per chunk
-    const strategy = new QAChunkingStrategy({ maxChunkChars: 80 })
+    const strategy = defineQAChunkingStrategy({ maxChunkChars: 80 })
     const chunks = strategy.chunk(log)
     expect(chunks.length).toBeGreaterThan(1)
     for (const chunk of chunks) {
@@ -130,7 +130,7 @@ describe('QAChunkingStrategy', () => {
         { role: 'assistant', content: longAnswer, timestamp: new Date() },
       ],
     }
-    const strategy = new QAChunkingStrategy()
+    const strategy = defineQAChunkingStrategy()
     const chunks = strategy.chunk(log)
     expect(chunks.length).toBeGreaterThan(1)
     for (const chunk of chunks) {

--- a/packages/hooks/tests/session-end-handler.test.ts
+++ b/packages/hooks/tests/session-end-handler.test.ts
@@ -2,8 +2,7 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { QAChunkingStrategy } from '../src/qa-chunking-strategy.js'
-import { SessionEndHandler } from '../src/session-end-handler.js'
+import { defineSessionEndHandler } from '../src/session-end-handler.js'
 
 describe('SessionEndHandler', () => {
   const testDir = join(tmpdir(), 'claude-memory-test-' + Date.now())
@@ -39,7 +38,7 @@ describe('SessionEndHandler', () => {
     ]
     writeFileSync(logPath, lines.join('\n'))
 
-    const handler = new SessionEndHandler(new QAChunkingStrategy(), mockSaveUseCase)
+    const handler = defineSessionEndHandler(mockSaveUseCase)
     await handler.handle(logPath, 'session-123', '/my/project')
 
     expect(mockSaveUseCase.saveConversation).toHaveBeenCalledTimes(1)
@@ -63,7 +62,7 @@ describe('SessionEndHandler', () => {
     ]
     writeFileSync(logPath, lines.join('\n'))
 
-    const handler = new SessionEndHandler(new QAChunkingStrategy(), mockSaveUseCase)
+    const handler = defineSessionEndHandler(mockSaveUseCase)
     await handler.handle(logPath, 'session-123')
 
     const callArg = vi.mocked(mockSaveUseCase.saveConversation).mock.calls[0]![0]
@@ -87,7 +86,7 @@ describe('SessionEndHandler', () => {
     ]
     writeFileSync(logPath, lines.join('\n'))
 
-    const handler = new SessionEndHandler(new QAChunkingStrategy(), mockSaveUseCase)
+    const handler = defineSessionEndHandler(mockSaveUseCase)
     await handler.handle(logPath, 'session-123')
 
     const callArg = vi.mocked(mockSaveUseCase.saveConversation).mock.calls[0]![0]
@@ -99,7 +98,7 @@ describe('SessionEndHandler', () => {
     const logPath = join(testDir, 'empty.jsonl')
     writeFileSync(logPath, '')
 
-    const handler = new SessionEndHandler(new QAChunkingStrategy(), mockSaveUseCase)
+    const handler = defineSessionEndHandler(mockSaveUseCase)
     await handler.handle(logPath, 'session-123')
 
     expect(mockSaveUseCase.saveConversation).toHaveBeenCalledWith(
@@ -124,7 +123,7 @@ describe('SessionEndHandler', () => {
     ]
     writeFileSync(logPath, lines.join('\n'))
 
-    const handler = new SessionEndHandler(new QAChunkingStrategy(), mockSaveUseCase)
+    const handler = defineSessionEndHandler(mockSaveUseCase)
     await handler.handle(logPath, 'session-123')
 
     const callArg = vi.mocked(mockSaveUseCase.saveConversation).mock.calls[0]![0]
@@ -149,7 +148,7 @@ describe('SessionEndHandler', () => {
     ]
     writeFileSync(logPath, lines.join('\n'))
 
-    const handler = new SessionEndHandler(new QAChunkingStrategy(), mockSaveUseCase)
+    const handler = defineSessionEndHandler(mockSaveUseCase)
     await handler.handle(logPath, 'session-123')
 
     const callArg = vi.mocked(mockSaveUseCase.saveConversation).mock.calls[0]![0]

--- a/packages/hooks/tests/session-start-handler.test.ts
+++ b/packages/hooks/tests/session-start-handler.test.ts
@@ -1,6 +1,6 @@
 import type { SearchFilter, SearchResult } from '@claude-memory/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { SessionStartHandler } from '../src/session-start-handler.js'
+import { defineSessionStartHandler } from '../src/session-start-handler.js'
 
 function createMemory(id: string, content: string): SearchResult {
   return {
@@ -36,7 +36,7 @@ describe('SessionStartHandler', () => {
       createMemory('2', 'Database is PostgreSQL'),
     ])
 
-    const handler = new SessionStartHandler(mockSearchUseCase)
+    const handler = defineSessionStartHandler(mockSearchUseCase)
     const result = await handler.handle('/my/project')
 
     expect(result).toContain('## Previous session context:')
@@ -49,7 +49,7 @@ describe('SessionStartHandler', () => {
   it('should return no-results message when no memories found', async () => {
     mockSearchUseCase.search.mockResolvedValue([])
 
-    const handler = new SessionStartHandler(mockSearchUseCase)
+    const handler = defineSessionStartHandler(mockSearchUseCase)
     const result = await handler.handle('/my/project')
 
     expect(result).toBe('No relevant memories found.')
@@ -58,7 +58,7 @@ describe('SessionStartHandler', () => {
   it('should pass projectPath as filter when provided', async () => {
     mockSearchUseCase.search.mockResolvedValue([])
 
-    const handler = new SessionStartHandler(mockSearchUseCase)
+    const handler = defineSessionStartHandler(mockSearchUseCase)
     await handler.handle('/my/project')
 
     expect(mockSearchUseCase.search).toHaveBeenCalledWith('project context', 5, {
@@ -69,7 +69,7 @@ describe('SessionStartHandler', () => {
   it('should search without filter when projectPath is undefined', async () => {
     mockSearchUseCase.search.mockResolvedValue([])
 
-    const handler = new SessionStartHandler(mockSearchUseCase)
+    const handler = defineSessionStartHandler(mockSearchUseCase)
     await handler.handle()
 
     expect(mockSearchUseCase.search).toHaveBeenCalledWith('project context', 5, undefined)
@@ -78,7 +78,7 @@ describe('SessionStartHandler', () => {
   it('should include score in formatted output', async () => {
     mockSearchUseCase.search.mockResolvedValue([createMemory('1', 'Some memory')])
 
-    const handler = new SessionStartHandler(mockSearchUseCase)
+    const handler = defineSessionStartHandler(mockSearchUseCase)
     const result = await handler.handle()
 
     expect(result).toContain('(score: 0.85)')

--- a/packages/mcp-server/src/container.ts
+++ b/packages/mcp-server/src/container.ts
@@ -12,7 +12,7 @@ import {
   defineUpdateMemoryUseCase,
 } from '@claude-memory/core'
 import { defineOnnxEmbeddingProvider } from '@claude-memory/embedding-onnx'
-import { QAChunkingStrategy } from '@claude-memory/hooks'
+import { defineQAChunkingStrategy } from '@claude-memory/hooks'
 import { definePostgresStorageRepository } from '@claude-memory/storage-postgres'
 import type { AppConfig } from './config.js'
 
@@ -26,7 +26,7 @@ export function createContainer(config: AppConfig) {
     maxConnections: config.dbPoolSize,
   })
   const embedding = defineOnnxEmbeddingProvider({ modelName: config.embeddingModel })
-  const chunking = new QAChunkingStrategy()
+  const chunking = defineQAChunkingStrategy()
 
   return {
     storage,

--- a/packages/mcp-server/src/session-end.ts
+++ b/packages/mcp-server/src/session-end.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { defineSaveMemoryUseCase } from '@claude-memory/core'
 import { defineOnnxEmbeddingProvider } from '@claude-memory/embedding-onnx'
-import { QAChunkingStrategy, SessionEndHandler } from '@claude-memory/hooks'
+import { defineQAChunkingStrategy, defineSessionEndHandler } from '@claude-memory/hooks'
 import { definePostgresStorageRepository } from '@claude-memory/storage-postgres'
 
 interface HookInput {
@@ -55,9 +55,9 @@ async function main() {
 
   try {
     await storage.migrate()
-    const chunking = new QAChunkingStrategy()
+    const chunking = defineQAChunkingStrategy()
     const saveUseCase = defineSaveMemoryUseCase(storage, embedding, chunking)
-    const handler = new SessionEndHandler(chunking, saveUseCase)
+    const handler = defineSessionEndHandler(saveUseCase)
     await handler.handle(transcriptPath, sessionId, projectPath)
   } finally {
     await storage.close()

--- a/packages/mcp-server/src/session-start.ts
+++ b/packages/mcp-server/src/session-start.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { defineSearchMemoryUseCase } from '@claude-memory/core'
 import { defineOnnxEmbeddingProvider } from '@claude-memory/embedding-onnx'
-import { SessionStartHandler } from '@claude-memory/hooks'
+import { defineSessionStartHandler } from '@claude-memory/hooks'
 import { definePostgresStorageRepository } from '@claude-memory/storage-postgres'
 
 /**
@@ -22,7 +22,7 @@ async function main() {
 
   try {
     const searchUseCase = defineSearchMemoryUseCase(storage, embedding)
-    const handler = new SessionStartHandler(searchUseCase)
+    const handler = defineSessionStartHandler(searchUseCase)
     const projectPath = process.env.PROJECT_PATH || process.cwd()
     const output = await handler.handle(projectPath)
     console.log(output)


### PR DESCRIPTION
Closes #183

## Summary

- hooks パッケージの 3 class を factory function に変換
- `SessionEndHandler` の **死にパラメータ** `chunking` を削除
- ADR-0010 追加（class-to-factory 移行の **完了宣言**）

これにより \`errors/memory-error.ts\` を除く全 source code が factory function 規約で統一されます。

## Why

ADR-0008 (core/use-cases) → ADR-0009 (embedding-onnx / storage-postgres) → ADR-0010 (hooks) の順で factory function 規約をコードベース全体に展開した最終段。論拠はすべて ADR-0008 と同じ:

1. hooks の 3 class はいずれも継承されていない
2. \`instanceof\` チェックもない
3. state は closure で表現可能
4. \`QAChunkingStrategy implements ChunkingStrategy\` は ADR-0009 の adapter カテゴリそのもの

「interface 層 wrapper か infrastructure adapter か」という境界線で悩まず、「core を import するなら factory（errors 以外）」という一原則で完結させる。

## Before / After

### SessionEndHandler — 死にパラメータ削除

\`\`\`diff
- export class SessionEndHandler {
-   constructor(
-     private readonly chunking: ChunkingStrategy,  // ← 使われていない
-     private readonly saveUseCase: SaveConversationCapable,
-   ) {}
-   async handle(...) {
-     const messages = this.parseLog(...)
-     await this.saveUseCase.saveConversation({ sessionId, projectPath, messages })
-   }
-   private parseLog(...) { ... }
- }
+ export function defineSessionEndHandler(saveUseCase: SaveConversationCapable): SessionEndHandler {
+   return {
+     async handle(...) {
+       const messages = parseLog(...)
+       await saveUseCase.saveConversation({ sessionId, projectPath, messages })
+     },
+   }
+ }
\`\`\`

\`chunking\` は class 時代から \`this.chunking\` が一度も参照されておらず、純粋な死にコード。チャンキングは \`saveUseCase.saveConversation\` 内で実行される（core の SaveMemoryUseCase 参照）。signature の嘘を消す機会として factory 化と同時に削除した。

### QAChunkingStrategy — private helper を module-level pure 関数へ

\`\`\`diff
- export class QAChunkingStrategy implements ChunkingStrategy {
-   private readonly maxChunkChars: number
-   chunk(conversation) { ... }
-   private extractQAPairs(conversation) { ... }
-   private splitChunk(chunk) { ... }
-   private splitIntoSentences(text) { ... }
- }
+ function extractQAPairs(conversation): Chunk[] { ... }
+ function splitIntoSentences(text): string[] { ... }
+ function splitChunk(chunk, maxChunkChars): Chunk[] { ... }
+
+ export function defineQAChunkingStrategy(options?): ChunkingStrategy {
+   const maxChunkChars = options?.maxChunkChars ?? DEFAULT_MAX_CHUNK_CHARS
+   return {
+     chunk(conversation) { ... }
+   }
+ }
\`\`\`

\`extractQAPairs\` / \`splitIntoSentences\` は DI 依存ゼロの pure 関数なので module-top へ移した（search-memory.ts と同じ方針）。\`splitChunk\` は \`maxChunkChars\` を引数で受けるようにした。

## Scope

| 変更 | ファイル |
|---|---|
| hooks 3 factory 書き換え | 3 |
| hooks index.ts re-export | 1 |
| hooks tests 更新（19/19 緑） | 3 |
| consumer 更新 | 3 (container / session-start / session-end) |
| CLAUDE.md 更新 | 1 |
| ADR-0009 に 0010 へのリンク追記 | 1 |
| ADR-0010 新規 | 1 |

## Test plan

- [x] \`pnpm --filter @claude-memory/hooks test\` — 19/19 緑
- [x] \`pnpm build\` — 全 5 パッケージ成功
- [x] \`pnpm lint\` — 0 エラー
- [x] \`pnpm knip\` — 未使用なし
- [x] \`pnpm dep-check\` — 依存違反なし
- [ ] mcp-server の session-start / session-end フック実地動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)