### PR TITLE
refactor: unify Hugging Face model cache between host and Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,9 @@ COPY scripts/ scripts/
 RUN pnpm install --frozen-lockfile
 RUN pnpm build
 
-# Pre-download the ONNX embedding model so it's cached in the image
-# Use pnpm exec to ensure correct module resolution with hoist=false
-RUN pnpm --filter @claude-memory/embedding-onnx exec node -e " \
-  import('./dist/onnx-embedding-provider.js').then(async (m) => { \
-    const p = m.defineOnnxEmbeddingProvider({ modelName: 'intfloat/multilingual-e5-small' }); \
-    const v = await p.embed('warmup'); \
-    console.log('Model cached. Dim:', v.length); \
-  }).catch(e => { console.error(e); process.exit(1); }) \
-"
+# ONNX embedding モデルは image に焼き込まない。実行時に host の ~/.cache/huggingface/
+# を bind mount 経由で共有し、host 側の session-start/end hook とキャッシュを一本化する。
+# docker-compose.yml の `volumes` 設定、または `docker run` の `-v` オプションを参照。
 
 # Save built dist files
 RUN find packages -name 'dist' -type d | tar cf /tmp/dist.tar -T -
@@ -43,7 +37,5 @@ WORKDIR /app
 COPY --from=builder /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml /app/.npmrc ./
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages ./packages
-# Copy ONNX model cache
-COPY --from=builder /root/.cache /root/.cache
 
 CMD ["node", "packages/mcp-server/dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ docker compose ps
         "-i",
         "--network",
         "claude-memory_default",
+        "-v",
+        "<your-home>/.cache/huggingface:/root/.cache/huggingface",
         "-e",
         "DATABASE_URL=postgresql://memory:memory@db:5432/claude_memory",
         "-e",
@@ -130,6 +132,10 @@ docker compose ps
 - **mcpServers** — Claude Code が `memory_save`, `memory_search` 等のMCPツールを使えるようになる。`docker run` で都度コンテナを起動し、stdio 経由で通信する
 - **hooks.SessionStart** — セッション開始時に `prompt` フックで関連する記憶を自動検索し、文脈を把握する
 - **hooks.SessionEnd** — セッション終了時に会話ログ（`transcript_path`）をQ&Aペアに分割してDBに自動保存する。ホスト側で `node` を直接実行する（Docker コンテナ内では会話ログファイルにアクセスできないため）。`<claude-memory-repo>` はクローン先の絶対パスに置き換える
+
+**モデルキャッシュの共有:** `defineOnnxEmbeddingProvider` は `env.cacheDir` を `~/.cache/huggingface/` に統一するコードを含む（transformers.js のデフォルトは pnpm パッケージ内部の `.cache/` で host と Docker container で異なるため）。上記設定の `-v <your-home>/.cache/huggingface:/root/.cache/huggingface` で、ホストとコンテナで同じ物理ディレクトリを bind mount 経由で共有する。`<your-home>` は自分のホームディレクトリの絶対パスに置き換える（例: macOS なら `/Users/you`、Linux なら `/home/you`）。Claude Code の `args` は shell 経由で展開されないため、`~` や `${HOME}` は使えず絶対パス必須。
+
+初回のみインターネット接続が必要（`intfloat/multilingual-e5-small`、約 465MB fp32）。2 回目以降はローカルキャッシュから即ロード。これにより image サイズが縮小し、host hook と Docker server でモデル二重ダウンロードが発生しない。キャッシュ位置は `HF_CACHE_DIR` 環境変数で上書き可能。
 
 設定後、Claude Code を再起動すると反映される。
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       EMBEDDING_MODEL: intfloat/multilingual-e5-small
       EMBEDDING_DIMENSION: "384"
       DB_POOL_SIZE: "10"
+    volumes:
+      # Hugging Face モデルキャッシュをホストと共有。session-start/end の host 側 hook と
+      # モデルを二重ダウンロードせず、image にも焼き込まない。初回はインターネット接続必須。
+      - ${HOME}/.cache/huggingface:/root/.cache/huggingface
 
 volumes:
   pgdata:

--- a/packages/embedding-onnx/src/onnx-embedding-provider.ts
+++ b/packages/embedding-onnx/src/onnx-embedding-provider.ts
@@ -1,6 +1,18 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import type { EmbeddingProvider } from '@claude-memory/core'
-import { type FeatureExtractionPipeline, pipeline } from '@huggingface/transformers'
+import { env, type FeatureExtractionPipeline, pipeline } from '@huggingface/transformers'
 import { DEFAULT_DIMENSION } from './constants.js'
+
+// transformers.js のモデルキャッシュ位置をユーザーホームの `~/.cache/huggingface/` に統一する。
+// デフォルトはパッケージ自身のディレクトリ配下（pnpm の内部パス）で、host と Docker container
+// では異なる node_modules パスになるためキャッシュが共有できない。HF_CACHE_DIR が設定されて
+// いればそれを優先し、未設定時は OS 共通パターンの ~/.cache/huggingface/ を使う。
+// host: /Users/<name>/.cache/huggingface (デフォルト)
+// Docker container: /root/.cache/huggingface (HOME=/root)
+// docker-compose.yml で host の ~/.cache/huggingface を container の /root/.cache/huggingface
+// に bind mount すると、両者が物理的に同じディレクトリを共有しモデルの二重ダウンロードを回避できる。
+env.cacheDir = process.env.HF_CACHE_DIR ?? join(homedir(), '.cache', 'huggingface')
 
 export interface OnnxEmbeddingConfig {
   modelName: string


### PR DESCRIPTION
Closes #187

## Summary

Host と Docker コンテナで ONNX embedding モデルのキャッシュを物理的に同じ \`~/.cache/huggingface/\` に統一。モデルの二重ダウンロードと image 焼き込みを解消。

## Why — 初期仮説が外れた記録

当初「Docker image にモデルを焼き込むのをやめて、host の \`~/.cache/huggingface/\` を bind mount すれば共有できる」と思い Docker 設定だけ変更した。**ローカル動作検証で発覚**:

> \`\`\`
> docker compose run mcp-server node -e "import transformers → print env.cacheDir"
> → "/app/node_modules/.pnpm/@huggingface+transformers@3.4.1/.../.cache/"
> \`\`\`

transformers.js (JS 版) の \`env.cacheDir\` デフォルトは **パッケージ自身のディレクトリ配下** で、host / container の \`~/.cache/huggingface/\` を一切参照しない (Python transformers とは仕様が違う)。つまり bind mount は **何も共有していなかった**。

真の cache 共有には **コードから \`env.cacheDir\` を明示的に設定する** しかない。

## 解決策

### 1. \`defineOnnxEmbeddingProvider\` で env.cacheDir を統一

\`\`\`ts
import { homedir } from 'node:os'
import { join } from 'node:path'
import { env } from '@huggingface/transformers'

env.cacheDir = process.env.HF_CACHE_DIR ?? join(homedir(), '.cache', 'huggingface')
\`\`\`

\`homedir()\` は:
- Host (macOS/Linux): \`/Users/name\` or \`/home/name\`
- Docker container (root): \`/root\`

いずれも \`{HOME}/.cache/huggingface\` 階層に解決されるため、パスパターンが揃う。

### 2. docker-compose に bind mount

\`\`\`yaml
mcp-server:
  volumes:
    - \${HOME}/.cache/huggingface:/root/.cache/huggingface
\`\`\`

host の \`/Users/.../\.cache/huggingface\` を container の \`/root/.cache/huggingface\` に露出。両者が物理的に同じディレクトリを指す。

### 3. Dockerfile: warmup と COPY 削除

builder stage の warmup RUN と runner stage の \`COPY --from=builder /root/.cache /root/.cache\` はもはや不要。image に焼き込まない。

### 4. README: docker run に \`-v\` 追加

Claude Code の \`mcpServers.args\` は shell 展開されないため、\`<your-home>\` プレースホルダ方式。絶対パスで書く必要がある旨を明記。

## 動作検証ログ（ローカル実測）

### テスト 1: フレッシュダウンロード

\`\`\`bash
$ rm -rf ~/.cache/huggingface && mkdir -p ~/.cache/huggingface
$ docker compose run --rm --no-deps mcp-server node -e "defineOnnxEmbeddingProvider({ modelName: 'intfloat/multilingual-e5-small' }).embed('hello')"
[test1] embed ok, dim: 384
$ ls ~/.cache/huggingface/
intfloat/
$ find ~/.cache/huggingface -name "*.onnx"
/Users/ogawahiromi/.cache/huggingface/intfloat/multilingual-e5-small/onnx/model.onnx
\`\`\`

✅ Container 内で動いたコードが、**host の** \`~/.cache/huggingface/\` に直接書き込んだ。

### テスト 2: キャッシュヒット

\`\`\`bash
$ time docker compose run --rm --no-deps mcp-server node -e "...embed('second')"
[test2] embed ok, dim: 384
real 3.635s  # container 起動 + node 起動 + キャッシュロード + embed、ネットワーク不要
\`\`\`

### テスト 3: Host から同じキャッシュを読む

\`\`\`bash
$ pnpm --filter @claude-memory/embedding-onnx test
 ✓ tests/onnx-embedding-provider.test.ts (6 tests) 888ms
real 2.255s  # ネットワーク無しで 888ms、キャッシュヒット確実
\`\`\`

✅ Container が書き込んだキャッシュを、host process が同じ場所から読んでいる。

## Scope

| 変更 | ファイル |
|---|---|
| \`env.cacheDir\` 設定 | \`packages/embedding-onnx/src/onnx-embedding-provider.ts\` |
| bind mount | \`docker-compose.yml\` |
| warmup / COPY 削除 | \`Dockerfile\` |
| \`-v\` 追加、説明 | \`README.md\` |

## トレードオフ

- 初回 \`docker compose up\` or host hook 初回起動でネットワーク必須 (fp32 で約 465MB)
- Container が root で実行されるため host の cache file は root 所有になりうる。通常運用では read 衝突は出ないが、permission 問題が出た場合は \`user:\` 指定を追加する余地あり
- Claude Code の \`mcpServers.args\` は shell 展開されないため \`<your-home>\` を手動書き換え必要

## Follow-up 候補（別 Issue）

- fp32 465MB は大きい。\`dtype: 'q8'\` 指定で quantized モデル (〜30MB) に切り替える検討
- \`Dockerfile\` line 8 の \`COPY scripts/ scripts/\` は build-time に不要（PR #182 で dead 化）。別 PR で削除検討

## Test plan

- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm build\` — 全 5 パッケージ成功
- [x] \`pnpm --filter @claude-memory/embedding-onnx test\` — 6/6 緑 (host cache 経由)
- [x] \`pnpm dep-check\` / \`pnpm knip\` — 違反なし
- [x] \`docker compose config\` — 構文 valid、\`${HOME}\` 展開確認
- [x] Docker rebuild + 3 パターンの動作検証（上記ログ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)