### PR TITLE
refactor: factory function migration cleanup (#189 #190 #192)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN corepack enable && corepack prepare pnpm@10.8.1 --activate
 WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml tsconfig.base.json .npmrc ./
 COPY packages/ packages/
-COPY scripts/ scripts/
 
 RUN pnpm install --frozen-lockfile
 RUN pnpm build

--- a/docs/engineer/architecture.md
+++ b/docs/engineer/architecture.md
@@ -21,30 +21,37 @@
 - `StorageRepository` — `save()`, `searchByKeyword()`, `searchByVector()`, `list()`, `delete()`, `exportAll()`, `deleteOlderThan()`, `countOlderThan()`
 - `ChunkingStrategy` — `chunk()`
 
-**ユースケース:**
-- `SaveMemoryUseCase` — 保存 + 重複チェック（コサイン類似度 >= 0.90）
-- `SearchMemoryUseCase` — ハイブリッド検索（pg_bigm + pgvector → RRF → 時間減衰 → アクセスブースト）
-- `UpdateMemoryUseCase` — 更新（content変更時のみ再embedding）
-- `DeleteMemoryUseCase` — 削除（存在チェック付き）
-- `ListMemoriesUseCase` — 一覧取得（ページネーション、最大100件）
-- `ExportMemoryUseCase` — 全記憶をJSON形式でエクスポート
-- `ImportMemoryUseCase` — JSONからインポート（embedding再計算）
-- `CleanupMemoryUseCase` — 古い記憶の削除（dry-run対応）
-- `GetStatsUseCase` — 統計情報取得
-- `ClearMemoryUseCase` — 全記憶削除
+**ユースケース（factory function で実装、詳細は [ADR-0008](../adr/0008-use-case-factory-functions.md)）:**
+
+UseCase は class ではなく `defineXxxUseCase(...)` の factory function として実装される。型は `ReturnType<typeof defineXxxUseCase>` で公開される。
+
+- `defineSaveMemoryUseCase` → `SaveMemoryUseCase` — 保存 + 重複チェック（コサイン類似度 >= 0.90）
+- `defineSearchMemoryUseCase` → `SearchMemoryUseCase` — ハイブリッド検索（pg_bigm + pgvector → RRF → 時間減衰 → アクセスブースト）
+- `defineUpdateMemoryUseCase` → `UpdateMemoryUseCase` — 更新（content変更時のみ再embedding）
+- `defineDeleteMemoryUseCase` → `DeleteMemoryUseCase` — 削除（存在チェック付き）
+- `defineListMemoriesUseCase` → `ListMemoriesUseCase` — 一覧取得（ページネーション、最大100件）
+- `defineExportMemoryUseCase` → `ExportMemoryUseCase` — 全記憶をJSON形式でエクスポート
+- `defineImportMemoryUseCase` → `ImportMemoryUseCase` — JSONからインポート（embedding再計算）
+- `defineCleanupMemoryUseCase` → `CleanupMemoryUseCase` — 古い記憶の削除（dry-run対応）
+- `defineGetStatsUseCase` → `GetStatsUseCase` — 統計情報取得
+- `defineClearMemoryUseCase` → `ClearMemoryUseCase` — 全記憶削除
+
+`errors/memory-error.ts` の `MemoryError` 系のみ、`instanceof` によるエラー分類が本質的機能のため class のまま据え置き。
 
 ### Infrastructure Layer
 
-coreのインターフェースを実装する（依存性逆転の原則）。
+coreのインターフェースを factory function で実装する（依存性逆転の原則、詳細は [ADR-0009](../adr/0009-infrastructure-adapter-factory-functions.md)）。
 
 **`@claude-memory/embedding-onnx`:**
-- `OnnxEmbeddingProvider` implements `EmbeddingProvider`
+- `defineOnnxEmbeddingProvider(config): EmbeddingProvider`
 - @huggingface/transformers でローカルONNX推論
 - multilingual-e5-small（384次元）がデフォルト
-- `embedBatch` は `Promise.all` で並列処理
+- モデルは `~/.cache/huggingface/` に lazy init でキャッシュ（host と Docker で共有可能）
+- `embedBatch` は 1 回の pipeline 呼び出しでバッチ実行
 
 **`@claude-memory/storage-postgres`:**
-- `PostgresStorageRepository` implements `StorageRepository`
+- `definePostgresStorageRepository(connectionString, options): PostgresStorageRepository`
+- 戻り値型 `PostgresStorageRepository` は `StorageRepository & { migrate(), close() }` で、interface 外のライフサイクル管理メソッドを露出
 - Drizzle ORM + postgres パッケージ
 - pgvector: HNSWインデックスによるベクトル近傍検索
 - pg_bigm: GINインデックスによる日本語対応キーワード検索
@@ -53,17 +60,18 @@ coreのインターフェースを実装する（依存性逆転の原則）。
 
 ### Interface Layer
 
-外部との接点。
+外部との接点。`@claude-memory/hooks` は interface 層 wrapper 群として factory function で実装される（詳細は [ADR-0010](../adr/0010-hooks-factory-functions.md)）。
 
 **`@claude-memory/mcp-server`:**
 - MCPツール10種を公開（stdio transport）
-- DIコンテナ（`createContainer`）で全パッケージを組み立て・注入
+- `createContainer(config)` で全パッケージの factory を組み立て・DI コンテナを生成（「実体を作る」ので `create` 動詞を使う）
 - Pino loggerで構造化ログ
 - 操作レイテンシをレスポンスに含む
 
 **`@claude-memory/hooks`:**
-- `SessionEndHandler` — PostSessionEndフックのエントリポイント
-- `QAChunkingStrategy` implements `ChunkingStrategy` — 会話をQ&Aペアに分割（最大1000文字/チャンク、文境界で分割）
+- `defineSessionStartHandler(searchUseCase) → SessionStartHandler` — セッション開始時に関連メモリを検索し、コンテキストを整形して返す
+- `defineSessionEndHandler(saveUseCase) → SessionEndHandler` — PostSessionEnd フックの処理本体（JSONLパース → 保存）
+- `defineQAChunkingStrategy(options?) → ChunkingStrategy` — 会話をQ&Aペアに分割（最大1000文字/チャンク、文境界で分割）
 
 ## パッケージ構成
 
@@ -207,11 +215,12 @@ k が大きいほど順位差の影響が小さくなる（結果が均等化さ
 
 ONNX Runtimeによるローカル推論。外部APIへの依存なし。
 
-- **モデル**: multilingual-e5-small（384次元、~100MB）
-- **初期化**: 遅延初期化（初回embed時にモデルをダウンロード、`~/.cache/`にキャッシュ）
+- **モデル**: multilingual-e5-small（384次元、fp32 で約 465MB）
+- **初期化**: 遅延初期化（初回embed時にモデルをダウンロード）
+- **キャッシュ位置**: `~/.cache/huggingface/`（`defineOnnxEmbeddingProvider` が `env.cacheDir` を明示設定。host と Docker container で bind mount により共有可能）
 - **プーリング**: mean pooling
 - **正規化**: L2 norm
-- **バッチ処理**: `Promise.all` で並列実行
+- **バッチ処理**: 1 回の `pipeline()` 呼び出しでバッチ推論
 
 ### インデックス戦略
 

--- a/packages/embedding-onnx/src/onnx-embedding-provider.ts
+++ b/packages/embedding-onnx/src/onnx-embedding-provider.ts
@@ -4,16 +4,6 @@ import type { EmbeddingProvider } from '@claude-memory/core'
 import { env, type FeatureExtractionPipeline, pipeline } from '@huggingface/transformers'
 import { DEFAULT_DIMENSION } from './constants.js'
 
-// transformers.js のモデルキャッシュ位置をユーザーホームの `~/.cache/huggingface/` に統一する。
-// デフォルトはパッケージ自身のディレクトリ配下（pnpm の内部パス）で、host と Docker container
-// では異なる node_modules パスになるためキャッシュが共有できない。HF_CACHE_DIR が設定されて
-// いればそれを優先し、未設定時は OS 共通パターンの ~/.cache/huggingface/ を使う。
-// host: /Users/<name>/.cache/huggingface (デフォルト)
-// Docker container: /root/.cache/huggingface (HOME=/root)
-// docker-compose.yml で host の ~/.cache/huggingface を container の /root/.cache/huggingface
-// に bind mount すると、両者が物理的に同じディレクトリを共有しモデルの二重ダウンロードを回避できる。
-env.cacheDir = process.env.HF_CACHE_DIR ?? join(homedir(), '.cache', 'huggingface')
-
 export interface OnnxEmbeddingConfig {
   modelName: string
 }
@@ -34,6 +24,22 @@ const MODEL_DIMENSIONS: Record<string, number> = {
  * @param config - ONNX モデル名を指定する設定
  */
 export function defineOnnxEmbeddingProvider(config: OnnxEmbeddingConfig): EmbeddingProvider {
+  // transformers.js のモデルキャッシュ位置をユーザーホームの `~/.cache/huggingface/` に統一する。
+  // デフォルトはパッケージ自身のディレクトリ配下（pnpm の内部パス）で、host と Docker container
+  // では異なる node_modules パスになるためキャッシュが共有できない。HF_CACHE_DIR が設定されて
+  // いればそれを優先し、未設定時は OS 共通パターンの ~/.cache/huggingface/ を使う。
+  //
+  // host: /Users/<name>/.cache/huggingface (デフォルト)
+  // Docker container: /root/.cache/huggingface (HOME=/root)
+  //
+  // docker-compose.yml で host の ~/.cache/huggingface を container の /root/.cache/huggingface
+  // に bind mount すると、両者が物理的に同じディレクトリを共有しモデルの二重ダウンロードを回避できる。
+  //
+  // NOTE: factory 呼び出しごとにべき等に代入される。transformers.js の env は singleton なので
+  // 複数の provider を同時に生成する場合は「最後に呼ばれた factory の設定」が支配的となるが、
+  // 現状このプロジェクトでは 1 factory = 1 provider のため問題にならない。
+  env.cacheDir = process.env.HF_CACHE_DIR ?? join(homedir(), '.cache', 'huggingface')
+
   const dimension = MODEL_DIMENSIONS[config.modelName] ?? DEFAULT_DIMENSION
   const cache: { extractor: Promise<FeatureExtractionPipeline> | null } = { extractor: null }
 


### PR DESCRIPTION
Closes #189, #190, #192

## Summary

PR #179 / #182 / #184 の class → factory function 移行後に残った 3 つの小粒フォローアップを 1 PR で処理。各 issue に 1 コミット対応。

## Commits

### #192: Dockerfile の dead \`COPY scripts/ scripts/\` を削除

\`scripts/download-model.mjs\` は PR #182 で削除済み、\`scripts/generate-all-docs.sh\` は host のドキュメント生成専用で Docker image では使わない。よって \`COPY scripts/ scripts/\` は builder stage でも runner stage でも参照されず dead。

**検証**: \`docker compose build mcp-server\` 成功。

### #190: \`env.cacheDir\` を module-top → factory 内に移動

PR #188 でモジュールトップに追加した \`env.cacheDir = ...\` の副作用を \`defineOnnxEmbeddingProvider\` の本体に移動。

- **Before**: モジュール import するだけで transformers.js の singleton state を書き換えていた
- **After**: factory 呼び出し時に代入。副作用タイミングが明示的

代入はべき等（同じ値を書く）、consumer は全て 1 factory = 1 provider なので複数 provider 競合なし。

**検証**: embedding-onnx tests 6/6 緑、キャッシュから model ロード確認。

### #189: \`docs/engineer/architecture.md\` を factory 化反映

ADR-0008 / 0009 / 0010 に対応する docs 更新:

- **Domain**: UseCase 10 個を \`define* → TypeName\` 記法に統一、\`errors/memory-error.ts\` 例外を注記
- **Infrastructure**: \`defineOnnxEmbeddingProvider\` / \`definePostgresStorageRepository\` に更新、後者の戻り値型 \`StorageRepository & { migrate, close }\` を説明
- **Interface**: hooks 3 factory を列挙、元は記載漏れだった \`SessionStartHandler\` を追加
- **mcp-server**: \`createContainer\` の「実体を作るので create 動詞を使う」という define との使い分けを明示
- **Embedding model**: キャッシュ位置を \`~/.cache/huggingface/\` に更新、サイズを fp32 で約 465MB と正確化（quantized 化は別 issue #193 で検討中）、\`embedBatch\` の記述を「\`Promise.all\` 並列」→「1 回の pipeline 呼び出しでバッチ」に修正（実装に整合）
- ADR-0008 / 0009 / 0010 へのリンクを追加

## Test plan

- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm --filter @claude-memory/core test\` — 56/56
- [x] \`pnpm --filter @claude-memory/hooks test\` — 19/19
- [x] \`pnpm --filter @claude-memory/embedding-onnx test\` — 6/6（実 model ロード）
- [x] \`pnpm --filter @claude-memory/storage-postgres test\` — 36/36
- [x] \`pnpm dep-check\` / \`pnpm knip\` — 違反なし
- [x] \`pnpm build\` — 全 5 パッケージ
- [x] \`docker compose config\` + \`docker compose build mcp-server\` — 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)